### PR TITLE
Update the semantics of Changeset.Status 

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -26,7 +26,7 @@ const (
 	OpStatusReverted          = "reverted"
 	ChangesetStatusReverted   = "reverted"
 	ChangesetStatusInProgress = "in-progress"
-	ChangesetStatusCommited   = "commited"
+	ChangesetStatusCommitted  = "committed"
 	// DefaultRetryAttempts specifies amount of retry attempts for checks
 	DefaultRetryAttempts = 60
 	// RetryPeriod is a period between Retries


### PR DESCRIPTION
This PR updates the semantics of Changeset.Status to use the fast-path for committed state - to avoid duplicate work.
 