### PR TITLE
Look for old pods based on old label set

### DIFF
--- a/ds.go
+++ b/ds.go
@@ -85,8 +85,8 @@ type DSControl struct {
 // collectPods returns pods created by this daemon set
 func (c *DSControl) collectPods(daemonSet *v1beta1.DaemonSet) (map[string]v1.Pod, error) {
 	var labels map[string]string
-	if c.daemonSet.Spec.Selector != nil {
-		labels = c.daemonSet.Spec.Selector.MatchLabels
+	if daemonSet.Spec.Selector != nil {
+		labels = daemonSet.Spec.Selector.MatchLabels
 	}
 	pods, err := collectPods(daemonSet.Namespace, labels, c.Entry, c.Client, func(ref api.ObjectReference) bool {
 		return ref.Kind == KindDaemonSet && ref.UID == daemonSet.UID

--- a/ds.go
+++ b/ds.go
@@ -84,11 +84,7 @@ type DSControl struct {
 
 // collectPods returns pods created by this daemon set
 func (c *DSControl) collectPods(daemonSet *v1beta1.DaemonSet) (map[string]v1.Pod, error) {
-	var labels map[string]string
-	if c.daemonSet.Spec.Selector != nil {
-		labels = c.daemonSet.Spec.Selector.MatchLabels
-	}
-	pods, err := collectPods(daemonSet.Namespace, labels, c.Entry, c.Client, func(ref api.ObjectReference) bool {
+	pods, err := collectPods(daemonSet.Namespace, nil, c.Entry, c.Client, func(ref api.ObjectReference) bool {
 		return ref.Kind == KindDaemonSet && ref.UID == daemonSet.UID
 	})
 	return pods, trace.Wrap(err)

--- a/ds.go
+++ b/ds.go
@@ -84,7 +84,11 @@ type DSControl struct {
 
 // collectPods returns pods created by this daemon set
 func (c *DSControl) collectPods(daemonSet *v1beta1.DaemonSet) (map[string]v1.Pod, error) {
-	pods, err := collectPods(daemonSet.Namespace, nil, c.Entry, c.Client, func(ref api.ObjectReference) bool {
+	var labels map[string]string
+	if c.daemonSet.Spec.Selector != nil {
+		labels = c.daemonSet.Spec.Selector.MatchLabels
+	}
+	pods, err := collectPods(daemonSet.Namespace, labels, c.Entry, c.Client, func(ref api.ObjectReference) bool {
 		return ref.Kind == KindDaemonSet && ref.UID == daemonSet.UID
 	})
 	return pods, trace.Wrap(err)


### PR DESCRIPTION
Encountered a bug where updating a DaemonSet with changed labels would not kill old pods. This was because the old pods did not match the new set of labels, so were never found for deletion.