### PR TITLE
Remove auto-generated labels when recreating jobs from changeset

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -23,6 +23,8 @@ const (
 	KindService               = "Service"
 	KindSecret                = "Secret"
 	KindJob                   = "Job"
+	BatchAPIVersion           = "batch/v1"
+	ControllerUIDLabel        = "controller-uid"
 	AnnotationCreatedBy       = "kubernetes.io/created-by"
 	OpStatusCreated           = "created"
 	OpStatusCompleted         = "completed"


### PR DESCRIPTION
This will fix the issue with reverting a previously removed job. When a job is queried from the API server, the resulting object contains a set of automatically generated labels (e.g. `controller-uid` which mirrors the UID of the old job object) that interfere with validation when using the same job object in Create call (e.g. when reverting a deleted job).

Also, use proper API namespace (Batch instead of Extensions) when working with jobs.
