### PR TITLE
Augment the APIs with trace.Wrap for coniser stack traces

### DIFF
--- a/job.go
+++ b/job.go
@@ -113,7 +113,7 @@ func (c *JobControl) Upsert(ctx context.Context) error {
 	c.job.ResourceVersion = ""
 	_, err = jobs.Create(&c.job)
 	if err != nil {
-		return ConvertError(err)
+		return trace.Wrap(ConvertError(err))
 	}
 
 	c.Info("job created successfully")


### PR DESCRIPTION
Augment the changeset APIs with trace.Wrap calls for easier debugging.