### PR TITLE
Dmitri/changeset create delete

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -177,7 +177,11 @@ func (cs *Changeset) Status(ctx context.Context, changesetNamespace, changesetNa
 						}
 					}
 				} else {
-					log.Debugf("%v has deleted resource, nothing to check", op)
+					log.Debugf("%v has deleted resource", op)
+					err := cs.status(ctx, []byte(op.From))
+					if err == nil || !trace.IsNotFound(err) {
+						return trace.CompareFailed("resource is still active: %v", err)
+					}
 				}
 			default:
 				return trace.BadParameter("unsupported operation status: %v", op.Status)

--- a/changeset.go
+++ b/changeset.go
@@ -177,8 +177,12 @@ func (cs *Changeset) Status(ctx context.Context, changesetNamespace, changesetNa
 						}
 					}
 				} else {
-					log.Debugf("%v has deleted resource", op)
-					err := cs.status(ctx, []byte(op.From))
+					info, err := GetOperationInfo(op)
+					if err != nil {
+						return trace.Wrap(err)
+					}
+					log.Debugf("%v has deleted resource", info)
+					err = cs.status(ctx, []byte(op.From))
 					if err == nil || !trace.IsNotFound(err) {
 						return trace.CompareFailed("resource is still active: %v", err)
 					}

--- a/changeset.go
+++ b/changeset.go
@@ -904,11 +904,25 @@ func (cs *Changeset) List(ctx context.Context, namespace string) (*ChangesetList
 	return cs.list(namespace)
 }
 
-// CreateOrRead returns an existing changeset or creates a new one given
-// the name and namespace.
+// Create creates a new one given the name and namespace.
 // The new changeset is created with status in-progress.
-func (cs *Changeset) CreateOrRead(namespace, name string) (*ChangesetResource, error) {
-	return cs.createOrRead(namespace, name, ChangesetSpec{Status: ChangesetStatusInProgress})
+// If there's already a changeset with this name in this namespace, AlreadyExists
+// error is returned.
+func (cs *Changeset) Create(namespace, name string) (*ChangesetResource, error) {
+	res := &ChangesetResource{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       KindChangeset,
+			APIVersion: ChangesetAPIVersion,
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: ChangesetSpec{
+			Status: ChangesetStatusInProgress,
+		},
+	}
+	return cs.create(res)
 }
 
 func (cs *Changeset) upsert(tr *ChangesetResource) (*ChangesetResource, error) {

--- a/changeset.go
+++ b/changeset.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/trace"
 	"k8s.io/client-go/1.4/kubernetes"
 	api "k8s.io/client-go/1.4/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/meta"
 	"k8s.io/client-go/1.4/pkg/api/unversioned"
 	"k8s.io/client-go/1.4/pkg/api/v1"
 	"k8s.io/client-go/1.4/pkg/apis/extensions/v1beta1"
@@ -170,7 +171,7 @@ func (cs *Changeset) Status(ctx context.Context, changesetNamespace, changesetNa
 				return trace.BadParameter("%v is not completed yet", tr)
 			case OpStatusCompleted, OpStatusReverted:
 				if op.To != "" {
-					err := cs.status(ctx, []byte(op.To))
+					err := cs.status(ctx, []byte(op.To), "")
 					if err != nil {
 						if op.Status != OpStatusReverted || !trace.IsNotFound(err) {
 							return trace.Wrap(err)
@@ -181,10 +182,10 @@ func (cs *Changeset) Status(ctx context.Context, changesetNamespace, changesetNa
 					if err != nil {
 						return trace.Wrap(err)
 					}
-					log.Debugf("%v has deleted resource", info)
-					err = cs.status(ctx, []byte(op.From))
+					err = cs.status(ctx, []byte(op.From), op.UID)
 					if err == nil || !trace.IsNotFound(err) {
-						return trace.CompareFailed("resource is still active: %v", err)
+						return trace.CompareFailed("%v with UID %q still active: %v",
+							formatMeta(info.From.ObjectMeta), op.UID, err)
 					}
 				}
 			default:
@@ -285,97 +286,185 @@ func (cs *Changeset) Revert(ctx context.Context, changesetNamespace, changesetNa
 	return trace.Wrap(err)
 }
 
-func (cs *Changeset) status(ctx context.Context, data []byte) error {
+func (cs *Changeset) status(ctx context.Context, data []byte, uid string) error {
 	header, err := ParseResourceHeader(bytes.NewReader(data))
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	switch header.Kind {
 	case KindDaemonSet:
-		return cs.statusDaemonSet(ctx, data)
+		return cs.statusDaemonSet(ctx, data, uid)
 	case KindJob:
-		return cs.statusJob(ctx, data)
+		return cs.statusJob(ctx, data, uid)
 	case KindReplicationController:
-		return cs.statusRC(ctx, data)
+		return cs.statusRC(ctx, data, uid)
 	case KindDeployment:
-		return cs.statusDeployment(ctx, data)
+		return cs.statusDeployment(ctx, data, uid)
 	case KindService:
-		return cs.statusService(ctx, data)
+		return cs.statusService(ctx, data, uid)
 	case KindSecret:
-		return cs.statusSecret(ctx, data)
+		return cs.statusSecret(ctx, data, uid)
 	case KindConfigMap:
-		return cs.statusConfigMap(ctx, data)
+		return cs.statusConfigMap(ctx, data, uid)
 	}
 	return trace.BadParameter("unsupported resource type %v for resource %v", header.Kind, header.Name)
 }
 
-func (cs *Changeset) statusDaemonSet(ctx context.Context, data []byte) error {
-	control, err := NewDSControl(DSConfig{Reader: bytes.NewReader(data), Client: cs.Client})
+func (cs *Changeset) statusDaemonSet(ctx context.Context, data []byte, uid string) error {
+	daemonset, err := ParseDaemonSet(bytes.NewReader(data))
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return control.Status(ctx, 1, 0)
+	if uid != "" {
+		existing, err := cs.Client.Extensions().DaemonSets(daemonset.Namespace).Get(daemonset.Name)
+		if err != nil {
+			return ConvertError(err)
+		}
+		if string(existing.GetUID()) != uid {
+			return trace.NotFound("daemonset with UID %v not found", uid)
+		}
+	}
+	control, err := NewDSControl(DSConfig{DaemonSet: daemonset, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return control.Status()
 }
 
-func (cs *Changeset) statusJob(ctx context.Context, data []byte) error {
+func (cs *Changeset) statusJob(ctx context.Context, data []byte, uid string) error {
 	job, err := ParseJob(bytes.NewReader(data))
 	if err != nil {
 		return trace.Wrap(err)
+	}
+	if uid != "" {
+		existing, err := cs.Client.Batch().Jobs(job.Namespace).Get(job.Name)
+		if err != nil {
+			return ConvertError(err)
+		}
+		if string(existing.GetUID()) != uid {
+			return trace.NotFound("job with UID %v not found", uid)
+		}
 	}
 	control, err := NewJobControl(JobConfig{job: job, Clientset: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return control.Status(ctx, 1, 0)
+	return control.Status()
 }
 
-func (cs *Changeset) statusRC(ctx context.Context, data []byte) error {
-	control, err := NewRCControl(RCConfig{Reader: bytes.NewReader(data), Client: cs.Client})
+func (cs *Changeset) statusRC(ctx context.Context, data []byte, uid string) error {
+	rc, err := ParseReplicationController(bytes.NewReader(data))
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return control.Status(ctx, 1, 0)
-}
-
-func (cs *Changeset) statusDeployment(ctx context.Context, data []byte) error {
-	control, err := NewDeploymentControl(DeploymentConfig{Reader: bytes.NewReader(data), Client: cs.Client})
+	if uid != "" {
+		existing, err := cs.Client.ReplicationControllers(rc.Namespace).Get(rc.Name)
+		if err != nil {
+			return ConvertError(err)
+		}
+		if string(existing.GetUID()) != uid {
+			return trace.NotFound("replication controller with UID %v not found", uid)
+		}
+	}
+	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return control.Status(ctx, 1, 0)
+	return control.Status()
 }
 
-func (cs *Changeset) statusService(ctx context.Context, data []byte) error {
-	control, err := NewServiceControl(ServiceConfig{Reader: bytes.NewReader(data), Client: cs.Client})
+func (cs *Changeset) statusDeployment(ctx context.Context, data []byte, uid string) error {
+	deployment, err := ParseDeployment(bytes.NewReader(data))
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return control.Status(ctx, 1, 0)
-}
-
-func (cs *Changeset) statusSecret(ctx context.Context, data []byte) error {
-	control, err := NewSecretControl(SecretConfig{Reader: bytes.NewReader(data), Client: cs.Client})
+	if uid != "" {
+		existing, err := cs.Client.Extensions().Deployments(deployment.Namespace).Get(deployment.Name)
+		if err != nil {
+			return ConvertError(err)
+		}
+		if string(existing.GetUID()) != uid {
+			return trace.NotFound("deployment with UID %v not found", uid)
+		}
+	}
+	control, err := NewDeploymentControl(DeploymentConfig{Deployment: deployment, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return control.Status(ctx, 1, 0)
+	return control.Status()
 }
 
-func (cs *Changeset) statusConfigMap(ctx context.Context, data []byte) error {
-	control, err := NewConfigMapControl(ConfigMapConfig{Reader: bytes.NewReader(data), Client: cs.Client})
+func (cs *Changeset) statusService(ctx context.Context, data []byte, uid string) error {
+	service, err := ParseService(bytes.NewReader(data))
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return control.Status(ctx, 1, 0)
+	if uid != "" {
+		existing, err := cs.Client.Services(service.Namespace).Get(service.Name)
+		if err != nil {
+			return ConvertError(err)
+		}
+		if string(existing.GetUID()) != uid {
+			return trace.NotFound("service with UID %v not found", uid)
+		}
+	}
+	control, err := NewServiceControl(ServiceConfig{Service: service, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return control.Status()
 }
 
-func (cs *Changeset) withDeleteOp(ctx context.Context, tr *ChangesetResource, obj interface{}, fn func() error) error {
+func (cs *Changeset) statusSecret(ctx context.Context, data []byte, uid string) error {
+	secret, err := ParseSecret(bytes.NewReader(data))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if uid != "" {
+		existing, err := cs.Client.Secrets(secret.Namespace).Get(secret.Name)
+		if err != nil {
+			return ConvertError(err)
+		}
+		if string(existing.GetUID()) != uid {
+			return trace.NotFound("secret with UID %v not found", uid)
+		}
+	}
+	control, err := NewSecretControl(SecretConfig{Secret: secret, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return control.Status()
+}
+
+func (cs *Changeset) statusConfigMap(ctx context.Context, data []byte, uid string) error {
+	configMap, err := ParseConfigMap(bytes.NewReader(data))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if uid != "" {
+		existing, err := cs.Client.ConfigMaps(configMap.Namespace).Get(configMap.Name)
+		if err != nil {
+			return ConvertError(err)
+		}
+		if string(existing.GetUID()) != uid {
+			return trace.NotFound("configmap with UID %v not found", uid)
+		}
+	}
+	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: configMap, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return control.Status()
+}
+
+func (cs *Changeset) withDeleteOp(ctx context.Context, tr *ChangesetResource, obj meta.Object, fn func() error) error {
 	data, err := goyaml.Marshal(obj)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	tr.Spec.Items = append(tr.Spec.Items, ChangesetItem{
 		From:              string(data),
+		UID:               string(obj.GetUID()),
 		Status:            OpStatusCreated,
 		CreationTimestamp: time.Now().UTC(),
 	})
@@ -636,7 +725,7 @@ func (cs *Changeset) revertSecret(ctx context.Context, item *ChangesetItem) erro
 	return control.Upsert(ctx)
 }
 
-func (cs *Changeset) withUpsertOp(ctx context.Context, tr *ChangesetResource, old interface{}, new interface{}, fn func() error) (*ChangesetResource, error) {
+func (cs *Changeset) withUpsertOp(ctx context.Context, tr *ChangesetResource, old meta.Object, new meta.Object, fn func() error) (*ChangesetResource, error) {
 	to, err := goyaml.Marshal(new)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -652,6 +741,7 @@ func (cs *Changeset) withUpsertOp(ctx context.Context, tr *ChangesetResource, ol
 			return nil, trace.Wrap(err)
 		}
 		item.From = string(from)
+		item.UID = string(old.GetUID())
 	}
 	tr.Spec.Items = append(tr.Spec.Items, item)
 	tr, err = cs.update(tr)
@@ -771,7 +861,7 @@ func (cs *Changeset) upsertDeployment(ctx context.Context, tr *ChangesetResource
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
-		log.Infof("existing deployment not found")
+		log.Debug("existing deployment not found")
 		currentDeployment = nil
 	}
 	control, err := NewDeploymentControl(DeploymentConfig{Deployment: deployment, Client: cs.Client})

--- a/configmap.go
+++ b/configmap.go
@@ -112,5 +112,5 @@ func (c *ConfigMapControl) Status(ctx context.Context, retryAttempts int, retryP
 func (c *ConfigMapControl) status() error {
 	configMaps := c.Client.Core().ConfigMaps(c.configMap.Namespace)
 	_, err := configMaps.Get(c.configMap.Name)
-	return trace.Wrap(err)
+	return ConvertError(err)
 }

--- a/configmap.go
+++ b/configmap.go
@@ -17,7 +17,6 @@ package rigging
 import (
 	"context"
 	"io"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
@@ -105,11 +104,7 @@ func (c *ConfigMapControl) Upsert(ctx context.Context) error {
 	return ConvertError(err)
 }
 
-func (c *ConfigMapControl) Status(ctx context.Context, retryAttempts int, retryPeriod time.Duration) error {
-	return pollStatus(ctx, retryAttempts, retryPeriod, c.status, c.Entry)
-}
-
-func (c *ConfigMapControl) status() error {
+func (c *ConfigMapControl) Status() error {
 	configMaps := c.Client.Core().ConfigMaps(c.configMap.Namespace)
 	_, err := configMaps.Get(c.configMap.Name)
 	return ConvertError(err)

--- a/deployment.go
+++ b/deployment.go
@@ -17,7 +17,6 @@ package rigging
 import (
 	"context"
 	"io"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
@@ -128,11 +127,7 @@ func (c *DeploymentControl) nodeSelector() labels.Selector {
 	return set.AsSelector()
 }
 
-func (c *DeploymentControl) Status(ctx context.Context, retryAttempts int, retryPeriod time.Duration) error {
-	return pollStatus(ctx, retryAttempts, retryPeriod, c.status, c.Entry)
-}
-
-func (c *DeploymentControl) status() error {
+func (c *DeploymentControl) Status() error {
 	deployments := c.Client.Extensions().Deployments(c.deployment.Namespace)
 	currentDeployment, err := deployments.Get(c.deployment.Name)
 	if err != nil {

--- a/ds.go
+++ b/ds.go
@@ -17,7 +17,6 @@ package rigging
 import (
 	"context"
 	"io"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
@@ -181,11 +180,7 @@ func (c *DSControl) nodeSelector() labels.Selector {
 	return set.AsSelector()
 }
 
-func (c *DSControl) Status(ctx context.Context, retryAttempts int, retryPeriod time.Duration) error {
-	return pollStatus(ctx, retryAttempts, retryPeriod, c.status, c.Entry)
-}
-
-func (c *DSControl) status() error {
+func (c *DSControl) Status() error {
 	daemons := c.Client.Extensions().DaemonSets(c.daemonSet.Namespace)
 	currentDS, err := daemons.Get(c.daemonSet.Name)
 	if err != nil {

--- a/ds.go
+++ b/ds.go
@@ -100,7 +100,7 @@ func (c *DSControl) Delete(ctx context.Context, cascade bool) error {
 	daemons := c.Client.Extensions().DaemonSets(c.daemonSet.Namespace)
 	currentDS, err := daemons.Get(c.daemonSet.Name)
 	if err != nil {
-		return trace.Wrap(err)
+		return ConvertError(err)
 	}
 	pods := c.Client.Core().Pods(c.daemonSet.Namespace)
 	currentPods, err := c.collectPods(currentDS)
@@ -110,7 +110,7 @@ func (c *DSControl) Delete(ctx context.Context, cascade bool) error {
 	c.Infof("deleting current daemon set")
 	err = daemons.Delete(c.daemonSet.Name, nil)
 	if err != nil {
-		return trace.Wrap(err)
+		return ConvertError(err)
 	}
 	if !cascade {
 		c.Infof("cascade not set, returning")
@@ -119,7 +119,7 @@ func (c *DSControl) Delete(ctx context.Context, cascade bool) error {
 	for _, pod := range currentPods {
 		log.Infof("deleting pod %v", pod.Name)
 		if err := pods.Delete(pod.Name, nil); err != nil {
-			return trace.Wrap(err)
+			return ConvertError(err)
 		}
 	}
 	return nil
@@ -149,7 +149,7 @@ func (c *DSControl) Upsert(ctx context.Context) error {
 		c.Infof("deleting current daemon set")
 		err = daemons.Delete(c.daemonSet.Name, nil)
 		if err != nil {
-			return trace.Wrap(err)
+			return ConvertError(err)
 		}
 	}
 	c.Infof("creating new daemon set")
@@ -158,7 +158,7 @@ func (c *DSControl) Upsert(ctx context.Context) error {
 	c.daemonSet.ResourceVersion = ""
 	_, err = daemons.Create(&c.daemonSet)
 	if err != nil {
-		return trace.Wrap(err)
+		return ConvertError(err)
 	}
 	c.Infof("created successfully")
 	if currentDS != nil {
@@ -166,7 +166,7 @@ func (c *DSControl) Upsert(ctx context.Context) error {
 		for _, pod := range currentPods {
 			c.Infof("deleting pod %v", pod.Name)
 			if err := pods.Delete(pod.Name, nil); err != nil {
-				return trace.Wrap(err)
+				return ConvertError(err)
 			}
 		}
 	}
@@ -189,7 +189,7 @@ func (c *DSControl) status() error {
 	daemons := c.Client.Extensions().DaemonSets(c.daemonSet.Namespace)
 	currentDS, err := daemons.Get(c.daemonSet.Name)
 	if err != nil {
-		return trace.Wrap(err)
+		return ConvertError(err)
 	}
 	currentPods, err := c.collectPods(currentDS)
 	if err != nil {
@@ -200,7 +200,7 @@ func (c *DSControl) status() error {
 		LabelSelector: c.nodeSelector(),
 	})
 	if err != nil {
-		return trace.Wrap(err)
+		return ConvertError(err)
 	}
 	return checkRunning(currentPods, nodes.Items, c.Entry)
 }

--- a/job.go
+++ b/job.go
@@ -16,7 +16,6 @@ package rigging
 
 import (
 	"context"
-	"time"
 
 	"github.com/gravitational/trace"
 
@@ -133,11 +132,7 @@ func (c *JobControl) Upsert(ctx context.Context) error {
 	return nil
 }
 
-func (c *JobControl) Status(ctx context.Context, retryAttempts int, retryPeriod time.Duration) error {
-	return pollStatus(ctx, retryAttempts, retryPeriod, c.status, c.Entry)
-}
-
-func (c *JobControl) status() error {
+func (c *JobControl) Status() error {
 	jobs := c.Batch().Jobs(c.job.Namespace)
 	job, err := jobs.Get(c.job.Name)
 	if err != nil {

--- a/rcc.go
+++ b/rcc.go
@@ -93,7 +93,7 @@ func (c *RCControl) collectPods(replicationController *v1.ReplicationController)
 		LabelSelector: set.AsSelector(),
 	})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, ConvertError(err)
 	}
 	c.Infof("collectPods(%v) -> %v", set, len(podList.Items))
 	currentPods := make([]v1.Pod, 0)
@@ -121,7 +121,7 @@ func (c *RCControl) Delete(ctx context.Context, cascade bool) error {
 	rcs := c.Client.Core().ReplicationControllers(c.replicationController.Namespace)
 	currentRC, err := rcs.Get(c.replicationController.Name)
 	if err != nil {
-		return trace.Wrap(err)
+		return ConvertError(err)
 	}
 	pods := c.Client.Core().Pods(c.replicationController.Namespace)
 	currentPods, err := c.collectPods(currentRC)
@@ -131,7 +131,7 @@ func (c *RCControl) Delete(ctx context.Context, cascade bool) error {
 	c.Infof("deleting")
 	err = rcs.Delete(c.replicationController.Name, nil)
 	if err != nil {
-		return trace.Wrap(err)
+		return ConvertError(err)
 	}
 	if !cascade {
 		c.Infof("cascade not set, returning")
@@ -140,7 +140,7 @@ func (c *RCControl) Delete(ctx context.Context, cascade bool) error {
 	for _, pod := range currentPods {
 		log.Infof("deleting pod %v", pod.Name)
 		if err := pods.Delete(pod.Name, nil); err != nil {
-			return trace.Wrap(err)
+			return ConvertError(err)
 		}
 	}
 	return nil
@@ -165,7 +165,7 @@ func (c *RCControl) Upsert(ctx context.Context) error {
 	control, err := NewRCControl(RCConfig{ReplicationController: currentRC, Client: c.Client})
 	err = control.Delete(ctx, true)
 	if err != nil {
-		return trace.Wrap(err)
+		return ConvertError(err)
 	}
 	_, err = rcs.Create(&c.replicationController)
 	return ConvertError(err)
@@ -192,7 +192,7 @@ func (c *RCControl) Status(ctx context.Context, retryAttempts int, retryPeriod t
 		rcs := c.Client.Core().ReplicationControllers(c.replicationController.Namespace)
 		currentRC, err := rcs.Get(c.replicationController.Name)
 		if err != nil {
-			return trace.Wrap(err)
+			return ConvertError(err)
 		}
 		var replicas int32 = 1
 		if currentRC.Spec.Replicas != nil {

--- a/secret.go
+++ b/secret.go
@@ -17,7 +17,6 @@ package rigging
 import (
 	"context"
 	"io"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
@@ -105,11 +104,7 @@ func (c *SecretControl) Upsert(ctx context.Context) error {
 	return ConvertError(err)
 }
 
-func (c *SecretControl) Status(ctx context.Context, retryAttempts int, retryPeriod time.Duration) error {
-	return pollStatus(ctx, retryAttempts, retryPeriod, c.status, c.Entry)
-}
-
-func (c *SecretControl) status() error {
+func (c *SecretControl) Status() error {
 	secrets := c.Client.Core().Secrets(c.secret.Namespace)
 	_, err := secrets.Get(c.secret.Name)
 	return ConvertError(err)

--- a/service.go
+++ b/service.go
@@ -17,7 +17,6 @@ package rigging
 import (
 	"context"
 	"io"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
@@ -107,11 +106,7 @@ func (c *ServiceControl) Upsert(ctx context.Context) error {
 	return ConvertError(err)
 }
 
-func (c *ServiceControl) Status(ctx context.Context, retryAttempts int, retryPeriod time.Duration) error {
-	return pollStatus(ctx, retryAttempts, retryPeriod, c.status, c.Entry)
-}
-
-func (c *ServiceControl) status() error {
+func (c *ServiceControl) Status() error {
 	services := c.Client.Core().Services(c.service.Namespace)
 	_, err := services.Get(c.service.Name)
 	return ConvertError(err)

--- a/spec.go
+++ b/spec.go
@@ -59,6 +59,7 @@ type ChangesetSpec struct {
 type ChangesetItem struct {
 	From              string    `json:"from"`
 	To                string    `json:"to"`
+	UID               string    `json:"uid"`
 	Status            string    `json:"status"`
 	CreationTimestamp time.Time `json:"time"`
 }
@@ -80,15 +81,15 @@ func (o *OperationInfo) Kind() string {
 
 func (o *OperationInfo) String() string {
 	if o.From != nil && o.To == nil {
-		return fmt.Sprintf("delete %v %v from namespace %v", o.From.Kind, o.From.Name, Namespace(o.From.Namespace))
+		return fmt.Sprintf("delete %v %v", o.From.Kind, formatMeta(o.From.ObjectMeta))
 	}
 	if o.From != nil && o.To != nil {
-		return fmt.Sprintf("update %v %v in namespace %v", o.To.Kind, o.To.Name, Namespace(o.To.Namespace))
+		return fmt.Sprintf("update %v %v", o.To.Kind, formatMeta(o.To.ObjectMeta))
 	}
 	if o.From == nil && o.To != nil {
-		return fmt.Sprintf("upsert %v %v in namespace %v", o.To.Kind, o.To.Name, Namespace(o.To.Namespace))
+		return fmt.Sprintf("upsert %v %v", o.To.Kind, formatMeta(o.To.ObjectMeta))
 	}
-	return "unknown operation"
+	return "invalid operation: both resources cannot be empty"
 }
 
 // GetOperationInfo returns operation information

--- a/tool/rig/main.go
+++ b/tool/rig/main.go
@@ -270,7 +270,8 @@ func upsert(ctx context.Context, client *kubernetes.Clientset, config *rest.Conf
 	return nil
 }
 
-func status(ctx context.Context, client *kubernetes.Clientset, config *rest.Config, namespace string, resource rigging.Ref, retryAttempts int, retryPeriod time.Duration) error {
+func status(ctx context.Context, client *kubernetes.Clientset, config *rest.Config, namespace string, resource rigging.Ref,
+	retryAttempts int, retryPeriod time.Duration) error {
 	switch resource.Kind {
 	case rigging.KindChangeset:
 		cs, err := rigging.NewChangeset(rigging.ChangesetConfig{
@@ -298,7 +299,7 @@ func status(ctx context.Context, client *kubernetes.Clientset, config *rest.Conf
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		return updater.Status(ctx, retryAttempts, retryPeriod)
+		return rigging.PollStatus(ctx, retryAttempts, retryPeriod, updater)
 	case rigging.KindDeployment:
 		deployment, err := client.Extensions().Deployments(namespace).Get(resource.Name)
 		if err != nil {
@@ -311,7 +312,7 @@ func status(ctx context.Context, client *kubernetes.Clientset, config *rest.Conf
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		return updater.Status(ctx, retryAttempts, retryPeriod)
+		return rigging.PollStatus(ctx, retryAttempts, retryPeriod, updater)
 	}
 	return trace.BadParameter("don't know how to check status of %v", resource.Kind)
 }

--- a/utils.go
+++ b/utils.go
@@ -95,7 +95,7 @@ func collectPods(namespace string, matchLabels map[string]string, entry *log.Ent
 		LabelSelector: set.AsSelector(),
 	})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, ConvertError(err)
 	}
 
 	pods := make(map[string]v1.Pod, 0)

--- a/utils.go
+++ b/utils.go
@@ -30,16 +30,12 @@ const (
 	ActionApply   action = "apply"
 )
 
-// StatusReporter enables an implementor to report status.
-// Status returns nil when the object has been completed
-// and error otherwise.
+// StatusReporter reports the status of the resource.
 type StatusReporter interface {
-	// Status returns the state of the object.
-	// Nil return signifies completion (created/deleted/updated),
-	// while non-nil return specifies an error condition.
+	// Status returns the state of the resource.
+	// Returns nil if successful (created/deleted/updated), otherwise an error
 	Status() error
-	// Infof logs the specified message and argument in this object's
-	// context.
+	// Infof logs the specified message and arguments in context of this resource
 	Infof(message string, args ...interface{})
 }
 


### PR DESCRIPTION
  * Add explicit `Create` API to Changeset to be able to determine if the changeset exists. This is to be able to avoid creating duplicate changeset items for use-cases when re-creating a changeset from scratch is not desirable.
  * Handle status query for deleted changeset items by keeping the object's UID and comparing it to the existing object's UID to determine if it's still active. UID is required to avoid problems with items with the same name that are updated by deleting the old resource and creating a new one.
  * Wrap all k8s API calls with `ConvertError` to translate error to trace context.