### PR TITLE
Report error on rig status for reverted changeset

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -154,6 +154,8 @@ func (cs *Changeset) Status(ctx context.Context, changesetNamespace, changesetNa
 	case ChangesetStatusCommitted:
 		// Nothing to do
 		return nil
+	case ChangesetStatusReverted:
+		return trace.BadParameter("changeset reverted")
 	}
 
 	if retryAttempts == 0 {


### PR DESCRIPTION
Another patch to enable updating a once rolled back installation.
Without this, `rig status` is success for reverted changeset and fails with `rig revert`.

Other options are:
  - silencing errors with `rig revert` so it's always successful (a variation is checking if the error is `already reverted`)
  - require clean up before running another update. This has the downside of letting one know that a cleanup is required only when the next failed update's rollback also fails.
  - ??

A better way is generating unique changeset IDs to avoid this problem altogether which requires non-trivial changes to the way changeset IDs are generated.