### PR TITLE
Update RBAC to v1

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -528,7 +528,7 @@ func (cs *Changeset) statusRole(ctx context.Context, data []byte, uid string) er
 		return trace.Wrap(err)
 	}
 	if uid != "" {
-		existing, err := cs.Client.RbacV1alpha1().Roles(role.Namespace).Get(role.Name, metav1.GetOptions{})
+		existing, err := cs.Client.RbacV1().Roles(role.Namespace).Get(role.Name, metav1.GetOptions{})
 		if err != nil {
 			return ConvertError(err)
 		}
@@ -549,7 +549,7 @@ func (cs *Changeset) statusClusterRole(ctx context.Context, data []byte, uid str
 		return trace.Wrap(err)
 	}
 	if uid != "" {
-		existing, err := cs.Client.RbacV1alpha1().ClusterRoles().Get(role.Name, metav1.GetOptions{})
+		existing, err := cs.Client.RbacV1().ClusterRoles().Get(role.Name, metav1.GetOptions{})
 		if err != nil {
 			return ConvertError(err)
 		}
@@ -570,7 +570,7 @@ func (cs *Changeset) statusRoleBinding(ctx context.Context, data []byte, uid str
 		return trace.Wrap(err)
 	}
 	if uid != "" {
-		existing, err := cs.Client.RbacV1alpha1().RoleBindings(binding.Namespace).Get(binding.Name, metav1.GetOptions{})
+		existing, err := cs.Client.RbacV1().RoleBindings(binding.Namespace).Get(binding.Name, metav1.GetOptions{})
 		if err != nil {
 			return ConvertError(err)
 		}
@@ -591,7 +591,7 @@ func (cs *Changeset) statusClusterRoleBinding(ctx context.Context, data []byte, 
 		return trace.Wrap(err)
 	}
 	if uid != "" {
-		existing, err := cs.Client.RbacV1alpha1().ClusterRoleBindings().Get(binding.Name, metav1.GetOptions{})
+		existing, err := cs.Client.RbacV1().ClusterRoleBindings().Get(binding.Name, metav1.GetOptions{})
 		if err != nil {
 			return ConvertError(err)
 		}
@@ -764,7 +764,7 @@ func (cs *Changeset) deleteServiceAccount(ctx context.Context, tr *ChangesetReso
 }
 
 func (cs *Changeset) deleteRole(ctx context.Context, tr *ChangesetResource, namespace, name string, cascade bool) error {
-	role, err := cs.Client.RbacV1alpha1().Roles(Namespace(namespace)).Get(name, metav1.GetOptions{})
+	role, err := cs.Client.RbacV1().Roles(Namespace(namespace)).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
@@ -778,7 +778,7 @@ func (cs *Changeset) deleteRole(ctx context.Context, tr *ChangesetResource, name
 }
 
 func (cs *Changeset) deleteClusterRole(ctx context.Context, tr *ChangesetResource, name string, cascade bool) error {
-	role, err := cs.Client.RbacV1alpha1().ClusterRoles().Get(name, metav1.GetOptions{})
+	role, err := cs.Client.RbacV1().ClusterRoles().Get(name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
@@ -792,7 +792,7 @@ func (cs *Changeset) deleteClusterRole(ctx context.Context, tr *ChangesetResourc
 }
 
 func (cs *Changeset) deleteRoleBinding(ctx context.Context, tr *ChangesetResource, namespace, name string, cascade bool) error {
-	binding, err := cs.Client.RbacV1alpha1().RoleBindings(Namespace(namespace)).Get(name, metav1.GetOptions{})
+	binding, err := cs.Client.RbacV1().RoleBindings(Namespace(namespace)).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
@@ -806,7 +806,7 @@ func (cs *Changeset) deleteRoleBinding(ctx context.Context, tr *ChangesetResourc
 }
 
 func (cs *Changeset) deleteClusterRoleBinding(ctx context.Context, tr *ChangesetResource, name string, cascade bool) error {
-	binding, err := cs.Client.RbacV1alpha1().ClusterRoleBindings().Get(name, metav1.GetOptions{})
+	binding, err := cs.Client.RbacV1().ClusterRoleBindings().Get(name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
@@ -1367,7 +1367,7 @@ func (cs *Changeset) upsertRole(ctx context.Context, tr *ChangesetResource, data
 		"cs":   tr.String(),
 		"role": formatMeta(role.ObjectMeta),
 	})
-	roles := cs.Client.RbacV1alpha1().Roles(role.Namespace)
+	roles := cs.Client.RbacV1().Roles(role.Namespace)
 	currentRole, err := roles.Get(role.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
@@ -1395,7 +1395,7 @@ func (cs *Changeset) upsertClusterRole(ctx context.Context, tr *ChangesetResourc
 		"cs":           tr.String(),
 		"cluster_role": formatMeta(role.ObjectMeta),
 	})
-	roles := cs.Client.RbacV1alpha1().ClusterRoles()
+	roles := cs.Client.RbacV1().ClusterRoles()
 	currentRole, err := roles.Get(role.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
@@ -1423,7 +1423,7 @@ func (cs *Changeset) upsertRoleBinding(ctx context.Context, tr *ChangesetResourc
 		"cs":           tr.String(),
 		"role_binding": formatMeta(binding.ObjectMeta),
 	})
-	bindings := cs.Client.RbacV1alpha1().RoleBindings(binding.Namespace)
+	bindings := cs.Client.RbacV1().RoleBindings(binding.Namespace)
 	currentBinding, err := bindings.Get(binding.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
@@ -1451,7 +1451,7 @@ func (cs *Changeset) upsertClusterRoleBinding(ctx context.Context, tr *Changeset
 		"cs": tr.String(),
 		"cluster_role_binding": formatMeta(binding.ObjectMeta),
 	})
-	bindings := cs.Client.RbacV1alpha1().ClusterRoleBindings()
+	bindings := cs.Client.RbacV1().ClusterRoleBindings()
 	currentBinding, err := bindings.Get(binding.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {

--- a/parse.go
+++ b/parse.go
@@ -22,7 +22,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-	"k8s.io/api/rbac/v1alpha1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -156,8 +156,8 @@ func ParseServiceAccount(r io.Reader) (*v1.ServiceAccount, error) {
 }
 
 // ParseRole parses an rbac role from the specified stream
-func ParseRole(r io.Reader) (*v1alpha1.Role, error) {
-	var role v1alpha1.Role
+func ParseRole(r io.Reader) (*rbacv1.Role, error) {
+	var role rbacv1.Role
 	err := yaml.NewYAMLOrJSONDecoder(r, DefaultBufferSize).Decode(&role)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -166,8 +166,8 @@ func ParseRole(r io.Reader) (*v1alpha1.Role, error) {
 }
 
 // ParseClusterRole parses an rbac cluster role from the specified stream
-func ParseClusterRole(r io.Reader) (*v1alpha1.ClusterRole, error) {
-	var role v1alpha1.ClusterRole
+func ParseClusterRole(r io.Reader) (*rbacv1.ClusterRole, error) {
+	var role rbacv1.ClusterRole
 	err := yaml.NewYAMLOrJSONDecoder(r, DefaultBufferSize).Decode(&role)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -176,8 +176,8 @@ func ParseClusterRole(r io.Reader) (*v1alpha1.ClusterRole, error) {
 }
 
 // ParseRoleBinding parses an rbac role binding from the specified stream
-func ParseRoleBinding(r io.Reader) (*v1alpha1.RoleBinding, error) {
-	var binding v1alpha1.RoleBinding
+func ParseRoleBinding(r io.Reader) (*rbacv1.RoleBinding, error) {
+	var binding rbacv1.RoleBinding
 	err := yaml.NewYAMLOrJSONDecoder(r, DefaultBufferSize).Decode(&binding)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -186,8 +186,8 @@ func ParseRoleBinding(r io.Reader) (*v1alpha1.RoleBinding, error) {
 }
 
 // ParseClusterRoleBinding parses an rbac cluster role binding from the specified stream
-func ParseClusterRoleBinding(r io.Reader) (*v1alpha1.ClusterRoleBinding, error) {
-	var binding v1alpha1.ClusterRoleBinding
+func ParseClusterRoleBinding(r io.Reader) (*rbacv1.ClusterRoleBinding, error) {
+	var binding rbacv1.ClusterRoleBinding
 	err := yaml.NewYAMLOrJSONDecoder(r, DefaultBufferSize).Decode(&binding)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/roles.go
+++ b/roles.go
@@ -19,7 +19,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
-	"k8s.io/api/rbac/v1alpha1"
+	"k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -42,7 +42,7 @@ func NewRoleControl(config RoleConfig) (*RoleControl, error) {
 // RoleConfig defines controller configuration
 type RoleConfig struct {
 	// Role is the existing role
-	Role v1alpha1.Role
+	Role v1.Role
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
@@ -60,21 +60,21 @@ func (c *RoleConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type RoleControl struct {
 	RoleConfig
-	v1alpha1.Role
+	v1.Role
 	*log.Entry
 }
 
 func (c *RoleControl) Delete(ctx context.Context, cascade bool) error {
 	c.Infof("delete %v", formatMeta(c.ObjectMeta))
 
-	err := c.Client.RbacV1alpha1().Roles(c.Namespace).Delete(c.Name, nil)
+	err := c.Client.RbacV1().Roles(c.Namespace).Delete(c.Name, nil)
 	return ConvertError(err)
 }
 
 func (c *RoleControl) Upsert(ctx context.Context) error {
 	c.Infof("upsert %v", formatMeta(c.ObjectMeta))
 
-	roles := c.Client.RbacV1alpha1().Roles(c.Namespace)
+	roles := c.Client.RbacV1().Roles(c.Namespace)
 	c.UID = ""
 	c.SelfLink = ""
 	c.ResourceVersion = ""
@@ -92,7 +92,7 @@ func (c *RoleControl) Upsert(ctx context.Context) error {
 }
 
 func (c *RoleControl) Status() error {
-	roles := c.Client.RbacV1alpha1().Roles(c.Namespace)
+	roles := c.Client.RbacV1().Roles(c.Namespace)
 	_, err := roles.Get(c.Name, metav1.GetOptions{})
 	return ConvertError(err)
 }
@@ -115,7 +115,7 @@ func NewClusterRoleControl(config ClusterRoleConfig) (*ClusterRoleControl, error
 // ClusterRoleConfig defines controller configuration
 type ClusterRoleConfig struct {
 	// Role is the existing cluster role
-	Role v1alpha1.ClusterRole
+	Role v1.ClusterRole
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
@@ -133,21 +133,21 @@ func (c *ClusterRoleConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type ClusterRoleControl struct {
 	ClusterRoleConfig
-	v1alpha1.ClusterRole
+	v1.ClusterRole
 	*log.Entry
 }
 
 func (c *ClusterRoleControl) Delete(ctx context.Context, cascade bool) error {
 	c.Infof("delete %v", formatMeta(c.ObjectMeta))
 
-	err := c.Client.RbacV1alpha1().ClusterRoles().Delete(c.Name, nil)
+	err := c.Client.RbacV1().ClusterRoles().Delete(c.Name, nil)
 	return ConvertError(err)
 }
 
 func (c *ClusterRoleControl) Upsert(ctx context.Context) error {
 	c.Infof("upsert %v", formatMeta(c.ObjectMeta))
 
-	roles := c.Client.RbacV1alpha1().ClusterRoles()
+	roles := c.Client.RbacV1().ClusterRoles()
 	c.UID = ""
 	c.SelfLink = ""
 	c.ResourceVersion = ""
@@ -165,7 +165,7 @@ func (c *ClusterRoleControl) Upsert(ctx context.Context) error {
 }
 
 func (c *ClusterRoleControl) Status() error {
-	roles := c.Client.RbacV1alpha1().ClusterRoles()
+	roles := c.Client.RbacV1().ClusterRoles()
 	_, err := roles.Get(c.Name, metav1.GetOptions{})
 	return ConvertError(err)
 }
@@ -188,7 +188,7 @@ func NewRoleBindingControl(config RoleBindingConfig) (*RoleBindingControl, error
 // RoleBindingConfig defines controller configuration
 type RoleBindingConfig struct {
 	// RoleBinding is the existing role binding
-	Binding v1alpha1.RoleBinding
+	Binding v1.RoleBinding
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
@@ -206,21 +206,21 @@ func (c *RoleBindingConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type RoleBindingControl struct {
 	RoleBindingConfig
-	v1alpha1.RoleBinding
+	v1.RoleBinding
 	*log.Entry
 }
 
 func (c *RoleBindingControl) Delete(ctx context.Context, cascade bool) error {
 	c.Infof("delete %v", formatMeta(c.ObjectMeta))
 
-	err := c.Client.RbacV1alpha1().RoleBindings(c.Namespace).Delete(c.Name, nil)
+	err := c.Client.RbacV1().RoleBindings(c.Namespace).Delete(c.Name, nil)
 	return ConvertError(err)
 }
 
 func (c *RoleBindingControl) Upsert(ctx context.Context) error {
 	c.Infof("upsert %v", formatMeta(c.ObjectMeta))
 
-	bindings := c.Client.RbacV1alpha1().RoleBindings(c.Namespace)
+	bindings := c.Client.RbacV1().RoleBindings(c.Namespace)
 	c.UID = ""
 	c.SelfLink = ""
 	c.ResourceVersion = ""
@@ -238,7 +238,7 @@ func (c *RoleBindingControl) Upsert(ctx context.Context) error {
 }
 
 func (c *RoleBindingControl) Status() error {
-	bindings := c.Client.RbacV1alpha1().RoleBindings(c.Namespace)
+	bindings := c.Client.RbacV1().RoleBindings(c.Namespace)
 	_, err := bindings.Get(c.Name, metav1.GetOptions{})
 	return ConvertError(err)
 }
@@ -261,7 +261,7 @@ func NewClusterRoleBindingControl(config ClusterRoleBindingConfig) (*ClusterRole
 // ClusterRoleBindingConfig defines controller configuration
 type ClusterRoleBindingConfig struct {
 	// Binding is the existing cluster role binding
-	Binding v1alpha1.ClusterRoleBinding
+	Binding v1.ClusterRoleBinding
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
@@ -279,21 +279,21 @@ func (c *ClusterRoleBindingConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type ClusterRoleBindingControl struct {
 	ClusterRoleBindingConfig
-	v1alpha1.ClusterRoleBinding
+	v1.ClusterRoleBinding
 	*log.Entry
 }
 
 func (c *ClusterRoleBindingControl) Delete(ctx context.Context, cascade bool) error {
 	c.Infof("delete %v", formatMeta(c.ObjectMeta))
 
-	err := c.Client.RbacV1alpha1().ClusterRoleBindings().Delete(c.Name, nil)
+	err := c.Client.RbacV1().ClusterRoleBindings().Delete(c.Name, nil)
 	return ConvertError(err)
 }
 
 func (c *ClusterRoleBindingControl) Upsert(ctx context.Context) error {
 	c.Infof("upsert %v", formatMeta(c.ObjectMeta))
 
-	bindings := c.Client.RbacV1alpha1().ClusterRoleBindings()
+	bindings := c.Client.RbacV1().ClusterRoleBindings()
 	c.UID = ""
 	c.SelfLink = ""
 	c.ResourceVersion = ""
@@ -311,7 +311,7 @@ func (c *ClusterRoleBindingControl) Upsert(ctx context.Context) error {
 }
 
 func (c *ClusterRoleBindingControl) Status() error {
-	bindings := c.Client.RbacV1alpha1().ClusterRoleBindings()
+	bindings := c.Client.RbacV1().ClusterRoleBindings()
 	_, err := bindings.Get(c.Name, metav1.GetOptions{})
 	return ConvertError(err)
 }


### PR DESCRIPTION
which seems to fix the upgrade failures on master:
```
ERROR: cannot create role "kube-system/monitoring": the server could not find the requested resource
```