### PR TITLE
Use owner reference field instead of annotation to determine pod owner.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -32,7 +32,6 @@ const (
 	KindClusterRoleBinding    = "ClusterRoleBinding"
 	KindPodSecurityPolicy     = "PodSecurityPolicy"
 	ControllerUIDLabel        = "controller-uid"
-	AnnotationCreatedBy       = "kubernetes.io/created-by"
 	OpStatusCreated           = "created"
 	OpStatusCompleted         = "completed"
 	OpStatusReverted          = "reverted"

--- a/deployment.go
+++ b/deployment.go
@@ -183,7 +183,7 @@ func (c *DeploymentControl) collectPods(deployment *v1beta2.Deployment) (map[str
 	if deployment.Spec.Selector != nil {
 		labels = deployment.Spec.Selector.MatchLabels
 	}
-	pods, err := CollectPods(deployment.Namespace, labels, c.Entry, c.Client, func(ref v1.ObjectReference) bool {
+	pods, err := CollectPods(deployment.Namespace, labels, c.Entry, c.Client, func(ref metav1.OwnerReference) bool {
 		return ref.Kind == KindDeployment && ref.UID == deployment.UID
 	})
 	return pods, ConvertError(err)

--- a/ds.go
+++ b/ds.go
@@ -88,7 +88,7 @@ func (c *DSControl) collectPods(daemonSet *v1beta1.DaemonSet) (map[string]v1.Pod
 	if daemonSet.Spec.Selector != nil {
 		labels = daemonSet.Spec.Selector.MatchLabels
 	}
-	pods, err := CollectPods(daemonSet.Namespace, labels, c.Entry, c.Client, func(ref v1.ObjectReference) bool {
+	pods, err := CollectPods(daemonSet.Namespace, labels, c.Entry, c.Client, func(ref metav1.OwnerReference) bool {
 		return ref.Kind == KindDaemonSet && ref.UID == daemonSet.UID
 	})
 	return pods, trace.Wrap(err)

--- a/job.go
+++ b/job.go
@@ -156,7 +156,7 @@ func (c *JobControl) collectPods(job *batchv1.Job) (map[string]v1.Pod, error) {
 	if job.Spec.Selector != nil {
 		labels = job.Spec.Selector.MatchLabels
 	}
-	pods, err := CollectPods(job.Namespace, labels, c.Entry, c.Clientset, func(ref v1.ObjectReference) bool {
+	pods, err := CollectPods(job.Namespace, labels, c.Entry, c.Clientset, func(ref metav1.OwnerReference) bool {
 		return ref.Kind == KindJob && ref.UID == job.UID
 	})
 	return pods, ConvertError(err)

--- a/parse.go
+++ b/parse.go
@@ -69,17 +69,6 @@ func ParseJob(r io.Reader) (*batchv1.Job, error) {
 	return &job, nil
 }
 
-// ParseSerializedReference parses serialized reference object
-// used in annotations
-func ParseSerializedReference(r io.Reader) (*v1.SerializedReference, error) {
-	ref := v1.SerializedReference{}
-	err := yaml.NewYAMLOrJSONDecoder(r, DefaultBufferSize).Decode(&ref)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &ref, nil
-}
-
 // ParseReplicationController parses replication controller
 func ParseReplicationController(r io.Reader) (*v1.ReplicationController, error) {
 	if r == nil {


### PR DESCRIPTION
This annotation was deprecated in v1.8 and removed in v1.9.

https://kubernetes.io/docs/reference/workloads-18-19/#created-by-annotation-is-deprecated
