### PR TITLE
Fix empty TypeMeta before serializing resource

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -371,7 +371,7 @@ func (cs *Changeset) statusDaemonSet(ctx context.Context, data []byte, uid strin
 			return trace.NotFound("daemonset with UID %v not found", uid)
 		}
 	}
-	control, err := NewDSControl(DSConfig{DaemonSet: *daemonset, Client: cs.Client})
+	control, err := NewDSControl(DSConfig{DaemonSet: daemonset, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -379,12 +379,12 @@ func (cs *Changeset) statusDaemonSet(ctx context.Context, data []byte, uid strin
 }
 
 func (cs *Changeset) statusStatefulSet(ctx context.Context, data []byte, uid string) error {
-	ss, err := ParseStatefulSet(bytes.NewReader(data))
+	statefulSet, err := ParseStatefulSet(bytes.NewReader(data))
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	if uid != "" {
-		existing, err := cs.Client.AppsV1().StatefulSets(ss.Namespace).Get(ss.Name, metav1.GetOptions{})
+		existing, err := cs.Client.AppsV1().StatefulSets(statefulSet.Namespace).Get(statefulSet.Name, metav1.GetOptions{})
 		if err != nil {
 			return ConvertError(err)
 		}
@@ -392,7 +392,7 @@ func (cs *Changeset) statusStatefulSet(ctx context.Context, data []byte, uid str
 			return trace.NotFound("statefulset with UID %v not found", uid)
 		}
 	}
-	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: *ss, Client: cs.Client})
+	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: statefulSet, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -413,7 +413,7 @@ func (cs *Changeset) statusJob(ctx context.Context, data []byte, uid string) err
 			return trace.NotFound("job with UID %v not found", uid)
 		}
 	}
-	control, err := NewJobControl(JobConfig{Job: *job, Clientset: cs.Client})
+	control, err := NewJobControl(JobConfig{Job: job, Clientset: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -435,7 +435,7 @@ func (cs *Changeset) statusRC(ctx context.Context, data []byte, uid string) erro
 			return trace.NotFound("replication controller with UID %v not found", uid)
 		}
 	}
-	control, err := NewRCControl(RCConfig{ReplicationController: *rc, Client: cs.Client})
+	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -456,7 +456,7 @@ func (cs *Changeset) statusDeployment(ctx context.Context, data []byte, uid stri
 			return trace.NotFound("deployment with UID %v not found", uid)
 		}
 	}
-	control, err := NewDeploymentControl(DeploymentConfig{Deployment: *deployment, Client: cs.Client})
+	control, err := NewDeploymentControl(DeploymentConfig{Deployment: deployment, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -477,7 +477,7 @@ func (cs *Changeset) statusService(ctx context.Context, data []byte, uid string)
 			return trace.NotFound("service with UID %v not found", uid)
 		}
 	}
-	control, err := NewServiceControl(ServiceConfig{Service: *service, Client: cs.Client})
+	control, err := NewServiceControl(ServiceConfig{Service: service, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -498,7 +498,7 @@ func (cs *Changeset) statusSecret(ctx context.Context, data []byte, uid string) 
 			return trace.NotFound("secret with UID %v not found", uid)
 		}
 	}
-	control, err := NewSecretControl(SecretConfig{Secret: *secret, Client: cs.Client})
+	control, err := NewSecretControl(SecretConfig{Secret: secret, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -519,7 +519,7 @@ func (cs *Changeset) statusConfigMap(ctx context.Context, data []byte, uid strin
 			return trace.NotFound("configmap with UID %v not found", uid)
 		}
 	}
-	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: *configMap, Client: cs.Client})
+	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: configMap, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -540,7 +540,7 @@ func (cs *Changeset) statusServiceAccount(ctx context.Context, data []byte, uid 
 			return trace.NotFound("service account with UID %v not found", uid)
 		}
 	}
-	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: *account, Client: cs.Client})
+	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: account, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -561,7 +561,7 @@ func (cs *Changeset) statusRole(ctx context.Context, data []byte, uid string) er
 			return trace.NotFound("role with UID %v not found", uid)
 		}
 	}
-	control, err := NewRoleControl(RoleConfig{Role: *role, Client: cs.Client})
+	control, err := NewRoleControl(RoleConfig{Role: role, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -582,7 +582,7 @@ func (cs *Changeset) statusClusterRole(ctx context.Context, data []byte, uid str
 			return trace.NotFound("cluster role with UID %v not found", uid)
 		}
 	}
-	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: *role, Client: cs.Client})
+	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: role, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -603,7 +603,7 @@ func (cs *Changeset) statusRoleBinding(ctx context.Context, data []byte, uid str
 			return trace.NotFound("role binding with UID %v not found", uid)
 		}
 	}
-	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: *binding, Client: cs.Client})
+	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: binding, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -624,7 +624,7 @@ func (cs *Changeset) statusClusterRoleBinding(ctx context.Context, data []byte, 
 			return trace.NotFound("cluster role binding with UID %v not found", uid)
 		}
 	}
-	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: *binding, Client: cs.Client})
+	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: binding, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -645,7 +645,7 @@ func (cs *Changeset) statusPodSecurityPolicy(ctx context.Context, data []byte, u
 			return trace.NotFound("pod security policy with UID %v not found", uid)
 		}
 	}
-	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: *policy, Client: cs.Client})
+	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: policy, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -681,25 +681,25 @@ func (cs *Changeset) deleteDaemonSet(ctx context.Context, tr *ChangesetResource,
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewDSControl(DSConfig{DaemonSet: *daemonSet, Client: cs.Client})
+	control, err := NewDSControl(DSConfig{DaemonSet: daemonSet, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.DaemonSet, func() error {
+	return cs.withDeleteOp(ctx, tr, control.DaemonSet, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
 
 func (cs *Changeset) deleteStatefulSet(ctx context.Context, tr *ChangesetResource, namespace, name string, cascade bool) error {
-	statefuleSet, err := cs.Client.AppsV1().StatefulSets(Namespace(namespace)).Get(name, metav1.GetOptions{})
+	statefulSet, err := cs.Client.AppsV1().StatefulSets(Namespace(namespace)).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: *statefuleSet, Client: cs.Client})
+	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: statefulSet, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.StatefulSet, func() error {
+	return cs.withDeleteOp(ctx, tr, control.StatefulSet, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -709,11 +709,11 @@ func (cs *Changeset) deleteJob(ctx context.Context, tr *ChangesetResource, names
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewJobControl(JobConfig{Job: *job, Clientset: cs.Client})
+	control, err := NewJobControl(JobConfig{Job: job, Clientset: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.Job, func() error {
+	return cs.withDeleteOp(ctx, tr, control.Job, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -723,11 +723,11 @@ func (cs *Changeset) deleteRC(ctx context.Context, tr *ChangesetResource, namesp
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewRCControl(RCConfig{ReplicationController: *rc, Client: cs.Client})
+	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.ReplicationController, func() error {
+	return cs.withDeleteOp(ctx, tr, control.ReplicationController, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -737,11 +737,11 @@ func (cs *Changeset) deleteDeployment(ctx context.Context, tr *ChangesetResource
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewDeploymentControl(DeploymentConfig{Deployment: *deployment, Client: cs.Client})
+	control, err := NewDeploymentControl(DeploymentConfig{Deployment: deployment, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.Deployment, func() error {
+	return cs.withDeleteOp(ctx, tr, control.Deployment, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -751,11 +751,11 @@ func (cs *Changeset) deleteService(ctx context.Context, tr *ChangesetResource, n
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewServiceControl(ServiceConfig{Service: *service, Client: cs.Client})
+	control, err := NewServiceControl(ServiceConfig{Service: service, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.Service, func() error {
+	return cs.withDeleteOp(ctx, tr, control.Service, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -765,11 +765,11 @@ func (cs *Changeset) deleteConfigMap(ctx context.Context, tr *ChangesetResource,
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: *configMap, Client: cs.Client})
+	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: configMap, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.ConfigMap, func() error {
+	return cs.withDeleteOp(ctx, tr, control.ConfigMap, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -779,11 +779,11 @@ func (cs *Changeset) deleteSecret(ctx context.Context, tr *ChangesetResource, na
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewSecretControl(SecretConfig{Secret: *secret, Client: cs.Client})
+	control, err := NewSecretControl(SecretConfig{Secret: secret, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.Secret, func() error {
+	return cs.withDeleteOp(ctx, tr, control.Secret, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -793,11 +793,11 @@ func (cs *Changeset) deleteServiceAccount(ctx context.Context, tr *ChangesetReso
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: *account, Client: cs.Client})
+	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: account, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.ServiceAccount, func() error {
+	return cs.withDeleteOp(ctx, tr, control.ServiceAccount, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -807,11 +807,11 @@ func (cs *Changeset) deleteRole(ctx context.Context, tr *ChangesetResource, name
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewRoleControl(RoleConfig{Role: *role, Client: cs.Client})
+	control, err := NewRoleControl(RoleConfig{Role: role, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.Role, func() error {
+	return cs.withDeleteOp(ctx, tr, control.Role, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -821,11 +821,11 @@ func (cs *Changeset) deleteClusterRole(ctx context.Context, tr *ChangesetResourc
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: *role, Client: cs.Client})
+	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: role, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.ClusterRole, func() error {
+	return cs.withDeleteOp(ctx, tr, control.ClusterRole, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -835,11 +835,11 @@ func (cs *Changeset) deleteRoleBinding(ctx context.Context, tr *ChangesetResourc
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: *binding, Client: cs.Client})
+	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: binding, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.RoleBinding, func() error {
+	return cs.withDeleteOp(ctx, tr, control.RoleBinding, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -849,11 +849,11 @@ func (cs *Changeset) deleteClusterRoleBinding(ctx context.Context, tr *Changeset
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: *binding, Client: cs.Client})
+	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: binding, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.ClusterRoleBinding, func() error {
+	return cs.withDeleteOp(ctx, tr, control.ClusterRoleBinding, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -863,11 +863,11 @@ func (cs *Changeset) deletePodSecurityPolicy(ctx context.Context, tr *ChangesetR
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: *policy, Client: cs.Client})
+	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: policy, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, &control.PodSecurityPolicy, func() error {
+	return cs.withDeleteOp(ctx, tr, control.PodSecurityPolicy, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -916,7 +916,7 @@ func (cs *Changeset) revertDaemonSet(ctx context.Context, item *ChangesetItem) e
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewDSControl(DSConfig{DaemonSet: *daemonSet, Client: cs.Client})
+	control, err := NewDSControl(DSConfig{DaemonSet: daemonSet, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -942,7 +942,7 @@ func (cs *Changeset) revertStatefulSet(ctx context.Context, item *ChangesetItem)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: *statefulSet, Client: cs.Client})
+	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: statefulSet, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -968,7 +968,7 @@ func (cs *Changeset) revertJob(ctx context.Context, item *ChangesetItem) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewJobControl(JobConfig{Job: *job, Clientset: cs.Client})
+	control, err := NewJobControl(JobConfig{Job: job, Clientset: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -994,7 +994,7 @@ func (cs *Changeset) revertReplicationController(ctx context.Context, item *Chan
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewRCControl(RCConfig{ReplicationController: *rc, Client: cs.Client})
+	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1020,7 +1020,7 @@ func (cs *Changeset) revertDeployment(ctx context.Context, item *ChangesetItem) 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewDeploymentControl(DeploymentConfig{Deployment: *deployment, Client: cs.Client})
+	control, err := NewDeploymentControl(DeploymentConfig{Deployment: deployment, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1042,11 +1042,11 @@ func (cs *Changeset) revertService(ctx context.Context, item *ChangesetItem) err
 	if len(resource) == 0 {
 		resource = item.To
 	}
-	svc, err := ParseService(strings.NewReader(resource))
+	service, err := ParseService(strings.NewReader(resource))
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewServiceControl(ServiceConfig{Service: *svc, Client: cs.Client})
+	control, err := NewServiceControl(ServiceConfig{Service: service, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1072,7 +1072,7 @@ func (cs *Changeset) revertConfigMap(ctx context.Context, item *ChangesetItem) e
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: *configMap, Client: cs.Client})
+	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: configMap, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1098,7 +1098,7 @@ func (cs *Changeset) revertSecret(ctx context.Context, item *ChangesetItem) erro
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewSecretControl(SecretConfig{Secret: *secret, Client: cs.Client})
+	control, err := NewSecretControl(SecretConfig{Secret: secret, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1124,7 +1124,7 @@ func (cs *Changeset) revertServiceAccount(ctx context.Context, item *ChangesetIt
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: *account, Client: cs.Client})
+	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: account, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1150,7 +1150,7 @@ func (cs *Changeset) revertRole(ctx context.Context, item *ChangesetItem) error 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewRoleControl(RoleConfig{Role: *role, Client: cs.Client})
+	control, err := NewRoleControl(RoleConfig{Role: role, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1176,7 +1176,7 @@ func (cs *Changeset) revertClusterRole(ctx context.Context, item *ChangesetItem)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: *role, Client: cs.Client})
+	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: role, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1202,7 +1202,7 @@ func (cs *Changeset) revertRoleBinding(ctx context.Context, item *ChangesetItem)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: *binding, Client: cs.Client})
+	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: binding, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1228,7 +1228,7 @@ func (cs *Changeset) revertClusterRoleBinding(ctx context.Context, item *Changes
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: *binding, Client: cs.Client})
+	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: binding, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1250,11 +1250,11 @@ func (cs *Changeset) revertPodSecurityPolicy(ctx context.Context, item *Changese
 	if len(resource) == 0 {
 		resource = item.To
 	}
-	psp, err := ParsePodSecurityPolicy(strings.NewReader(resource))
+	policy, err := ParsePodSecurityPolicy(strings.NewReader(resource))
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: *psp, Client: cs.Client})
+	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: policy, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1322,14 +1322,14 @@ func (cs *Changeset) upsertJob(ctx context.Context, tr *ChangesetResource, data 
 		log.Info("existing job not found")
 		current = nil
 	}
-	control, err := NewJobControl(JobConfig{Job: *job, Clientset: cs.Client})
+	control, err := NewJobControl(JobConfig{Job: job, Clientset: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaJob(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.Job, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.Job, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1354,14 +1354,14 @@ func (cs *Changeset) upsertDaemonSet(ctx context.Context, tr *ChangesetResource,
 		log.Debug("existing daemonset not found")
 		current = nil
 	}
-	control, err := NewDSControl(DSConfig{DaemonSet: *daemonSet, Client: cs.Client})
+	control, err := NewDSControl(DSConfig{DaemonSet: daemonSet, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaDaemonset(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.DaemonSet, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.DaemonSet, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1386,14 +1386,14 @@ func (cs *Changeset) upsertStatefulSet(ctx context.Context, tr *ChangesetResourc
 		log.Debug("existing statefulset not found")
 		current = nil
 	}
-	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: *statefulSet, Client: cs.Client})
+	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: statefulSet, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaStatefulSet(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.StatefulSet, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.StatefulSet, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1418,14 +1418,14 @@ func (cs *Changeset) upsertRC(ctx context.Context, tr *ChangesetResource, data [
 		log.Debug("existing replication controller not found")
 		current = nil
 	}
-	control, err := NewRCControl(RCConfig{ReplicationController: *rc, Client: cs.Client})
+	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaReplicationController(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.ReplicationController, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.ReplicationController, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1450,14 +1450,14 @@ func (cs *Changeset) upsertDeployment(ctx context.Context, tr *ChangesetResource
 		log.Debug("existing deployment not found")
 		current = nil
 	}
-	control, err := NewDeploymentControl(DeploymentConfig{Deployment: *deployment, Client: cs.Client})
+	control, err := NewDeploymentControl(DeploymentConfig{Deployment: deployment, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaDeployment(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.Deployment, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.Deployment, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1482,14 +1482,14 @@ func (cs *Changeset) upsertService(ctx context.Context, tr *ChangesetResource, d
 		log.Debug("existing service not found")
 		current = nil
 	}
-	control, err := NewServiceControl(ServiceConfig{Service: *service, Client: cs.Client})
+	control, err := NewServiceControl(ServiceConfig{Service: service, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaService(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.Service, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.Service, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1513,14 +1513,14 @@ func (cs *Changeset) upsertServiceAccount(ctx context.Context, tr *ChangesetReso
 		log.Debug("existing service account not found")
 		current = nil
 	}
-	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: *account, Client: cs.Client})
+	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: account, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaServiceAccount(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.ServiceAccount, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.ServiceAccount, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1544,14 +1544,14 @@ func (cs *Changeset) upsertRole(ctx context.Context, tr *ChangesetResource, data
 		log.Debug("existing role not found")
 		current = nil
 	}
-	control, err := NewRoleControl(RoleConfig{Role: *role, Client: cs.Client})
+	control, err := NewRoleControl(RoleConfig{Role: role, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaRole(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.Role, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.Role, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1575,14 +1575,14 @@ func (cs *Changeset) upsertClusterRole(ctx context.Context, tr *ChangesetResourc
 		log.Debug("existing cluster role not found")
 		current = nil
 	}
-	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: *role, Client: cs.Client})
+	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: role, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaClusterRole(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.ClusterRole, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.ClusterRole, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1606,14 +1606,14 @@ func (cs *Changeset) upsertRoleBinding(ctx context.Context, tr *ChangesetResourc
 		log.Debug("existing role binding not found")
 		current = nil
 	}
-	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: *binding, Client: cs.Client})
+	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: binding, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaRoleBinding(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.RoleBinding, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.RoleBinding, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1637,14 +1637,14 @@ func (cs *Changeset) upsertClusterRoleBinding(ctx context.Context, tr *Changeset
 		log.Debug("existing cluster role binding not found")
 		current = nil
 	}
-	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: *binding, Client: cs.Client})
+	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: binding, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaClusterRoleBinding(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.ClusterRoleBinding, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.ClusterRoleBinding, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1668,14 +1668,14 @@ func (cs *Changeset) upsertPodSecurityPolicy(ctx context.Context, tr *ChangesetR
 		log.Debug("existing pod security policy not found")
 		current = nil
 	}
-	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: *policy, Client: cs.Client})
+	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: policy, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaPodSecurityPolicy(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.PodSecurityPolicy, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.PodSecurityPolicy, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1700,14 +1700,14 @@ func (cs *Changeset) upsertConfigMap(ctx context.Context, tr *ChangesetResource,
 		log.Debug("existing configmap not found")
 		current = nil
 	}
-	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: *configMap, Client: cs.Client})
+	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: configMap, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaConfigMap(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.ConfigMap, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.ConfigMap, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1732,14 +1732,14 @@ func (cs *Changeset) upsertSecret(ctx context.Context, tr *ChangesetResource, da
 		log.Debug("existing secret not found")
 		current = nil
 	}
-	control, err := NewSecretControl(SecretConfig{Secret: *secret, Client: cs.Client})
+	control, err := NewSecretControl(SecretConfig{Secret: secret, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if current != nil {
 		updateTypeMetaSecret(current)
 	}
-	return cs.withUpsertOp(ctx, tr, current, &control.Secret, func() error {
+	return cs.withUpsertOp(ctx, tr, current, control.Secret, func() error {
 		return control.Upsert(ctx)
 	})
 }

--- a/changeset.go
+++ b/changeset.go
@@ -363,7 +363,7 @@ func (cs *Changeset) statusDaemonSet(ctx context.Context, data []byte, uid strin
 		return trace.Wrap(err)
 	}
 	if uid != "" {
-		existing, err := cs.Client.Apps().DaemonSets(daemonset.Namespace).Get(daemonset.Name, metav1.GetOptions{})
+		existing, err := cs.Client.AppsV1().DaemonSets(daemonset.Namespace).Get(daemonset.Name, metav1.GetOptions{})
 		if err != nil {
 			return ConvertError(err)
 		}
@@ -371,7 +371,7 @@ func (cs *Changeset) statusDaemonSet(ctx context.Context, data []byte, uid strin
 			return trace.NotFound("daemonset with UID %v not found", uid)
 		}
 	}
-	control, err := NewDSControl(DSConfig{DaemonSet: daemonset, Client: cs.Client})
+	control, err := NewDSControl(DSConfig{DaemonSet: *daemonset, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -392,7 +392,7 @@ func (cs *Changeset) statusStatefulSet(ctx context.Context, data []byte, uid str
 			return trace.NotFound("statefulset with UID %v not found", uid)
 		}
 	}
-	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: ss, Client: cs.Client})
+	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: *ss, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -413,7 +413,7 @@ func (cs *Changeset) statusJob(ctx context.Context, data []byte, uid string) err
 			return trace.NotFound("job with UID %v not found", uid)
 		}
 	}
-	control, err := NewJobControl(JobConfig{Job: job, Clientset: cs.Client})
+	control, err := NewJobControl(JobConfig{Job: *job, Clientset: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -435,7 +435,7 @@ func (cs *Changeset) statusRC(ctx context.Context, data []byte, uid string) erro
 			return trace.NotFound("replication controller with UID %v not found", uid)
 		}
 	}
-	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
+	control, err := NewRCControl(RCConfig{ReplicationController: *rc, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -448,7 +448,7 @@ func (cs *Changeset) statusDeployment(ctx context.Context, data []byte, uid stri
 		return trace.Wrap(err)
 	}
 	if uid != "" {
-		existing, err := cs.Client.Apps().Deployments(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{})
+		existing, err := cs.Client.AppsV1().Deployments(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{})
 		if err != nil {
 			return ConvertError(err)
 		}
@@ -456,7 +456,7 @@ func (cs *Changeset) statusDeployment(ctx context.Context, data []byte, uid stri
 			return trace.NotFound("deployment with UID %v not found", uid)
 		}
 	}
-	control, err := NewDeploymentControl(DeploymentConfig{Deployment: deployment, Client: cs.Client})
+	control, err := NewDeploymentControl(DeploymentConfig{Deployment: *deployment, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -477,7 +477,7 @@ func (cs *Changeset) statusService(ctx context.Context, data []byte, uid string)
 			return trace.NotFound("service with UID %v not found", uid)
 		}
 	}
-	control, err := NewServiceControl(ServiceConfig{Service: service, Client: cs.Client})
+	control, err := NewServiceControl(ServiceConfig{Service: *service, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -498,7 +498,7 @@ func (cs *Changeset) statusSecret(ctx context.Context, data []byte, uid string) 
 			return trace.NotFound("secret with UID %v not found", uid)
 		}
 	}
-	control, err := NewSecretControl(SecretConfig{Secret: secret, Client: cs.Client})
+	control, err := NewSecretControl(SecretConfig{Secret: *secret, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -519,7 +519,7 @@ func (cs *Changeset) statusConfigMap(ctx context.Context, data []byte, uid strin
 			return trace.NotFound("configmap with UID %v not found", uid)
 		}
 	}
-	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: configMap, Client: cs.Client})
+	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: *configMap, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -540,7 +540,7 @@ func (cs *Changeset) statusServiceAccount(ctx context.Context, data []byte, uid 
 			return trace.NotFound("service account with UID %v not found", uid)
 		}
 	}
-	control, err := NewServiceAccountControl(ServiceAccountConfig{Account: *account, Client: cs.Client})
+	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: *account, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -582,7 +582,7 @@ func (cs *Changeset) statusClusterRole(ctx context.Context, data []byte, uid str
 			return trace.NotFound("cluster role with UID %v not found", uid)
 		}
 	}
-	control, err := NewClusterRoleControl(ClusterRoleConfig{Role: *role, Client: cs.Client})
+	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: *role, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -603,7 +603,7 @@ func (cs *Changeset) statusRoleBinding(ctx context.Context, data []byte, uid str
 			return trace.NotFound("role binding with UID %v not found", uid)
 		}
 	}
-	control, err := NewRoleBindingControl(RoleBindingConfig{Binding: *binding, Client: cs.Client})
+	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: *binding, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -624,7 +624,7 @@ func (cs *Changeset) statusClusterRoleBinding(ctx context.Context, data []byte, 
 			return trace.NotFound("cluster role binding with UID %v not found", uid)
 		}
 	}
-	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{Binding: *binding, Client: cs.Client})
+	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: *binding, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -645,7 +645,7 @@ func (cs *Changeset) statusPodSecurityPolicy(ctx context.Context, data []byte, u
 			return trace.NotFound("pod security policy with UID %v not found", uid)
 		}
 	}
-	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{Policy: *policy, Client: cs.Client})
+	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: *policy, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -677,30 +677,29 @@ func (cs *Changeset) withDeleteOp(ctx context.Context, tr *ChangesetResource, ob
 }
 
 func (cs *Changeset) deleteDaemonSet(ctx context.Context, tr *ChangesetResource, namespace, name string, cascade bool) error {
-	ds, err := cs.Client.Apps().DaemonSets(Namespace(namespace)).Get(name, metav1.GetOptions{})
+	daemonSet, err := cs.Client.AppsV1().DaemonSets(Namespace(namespace)).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewDSControl(DSConfig{DaemonSet: ds, Client: cs.Client})
+	control, err := NewDSControl(DSConfig{DaemonSet: *daemonSet, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, ds, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.DaemonSet, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
 
 func (cs *Changeset) deleteStatefulSet(ctx context.Context, tr *ChangesetResource, namespace, name string, cascade bool) error {
-	ss, err := cs.Client.AppsV1().StatefulSets(Namespace(namespace)).Get(name, metav1.GetOptions{})
+	statefuleSet, err := cs.Client.AppsV1().StatefulSets(Namespace(namespace)).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: ss, Client: cs.Client})
+	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: *statefuleSet, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	return cs.withDeleteOp(ctx, tr, ss, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.StatefulSet, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -710,11 +709,11 @@ func (cs *Changeset) deleteJob(ctx context.Context, tr *ChangesetResource, names
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewJobControl(JobConfig{Job: job, Clientset: cs.Client})
+	control, err := NewJobControl(JobConfig{Job: *job, Clientset: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, job, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.Job, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -724,25 +723,25 @@ func (cs *Changeset) deleteRC(ctx context.Context, tr *ChangesetResource, namesp
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
+	control, err := NewRCControl(RCConfig{ReplicationController: *rc, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, rc, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.ReplicationController, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
 
 func (cs *Changeset) deleteDeployment(ctx context.Context, tr *ChangesetResource, namespace, name string, cascade bool) error {
-	deployment, err := cs.Client.Apps().Deployments(Namespace(namespace)).Get(name, metav1.GetOptions{})
+	deployment, err := cs.Client.AppsV1().Deployments(Namespace(namespace)).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewDeploymentControl(DeploymentConfig{Deployment: deployment, Client: cs.Client})
+	control, err := NewDeploymentControl(DeploymentConfig{Deployment: *deployment, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, deployment, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.Deployment, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -752,11 +751,11 @@ func (cs *Changeset) deleteService(ctx context.Context, tr *ChangesetResource, n
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewServiceControl(ServiceConfig{Service: service, Client: cs.Client})
+	control, err := NewServiceControl(ServiceConfig{Service: *service, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, service, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.Service, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -766,11 +765,11 @@ func (cs *Changeset) deleteConfigMap(ctx context.Context, tr *ChangesetResource,
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: configMap, Client: cs.Client})
+	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: *configMap, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, configMap, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.ConfigMap, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -780,11 +779,11 @@ func (cs *Changeset) deleteSecret(ctx context.Context, tr *ChangesetResource, na
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewSecretControl(SecretConfig{Secret: secret, Client: cs.Client})
+	control, err := NewSecretControl(SecretConfig{Secret: *secret, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, secret, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.Secret, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -794,11 +793,11 @@ func (cs *Changeset) deleteServiceAccount(ctx context.Context, tr *ChangesetReso
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewServiceAccountControl(ServiceAccountConfig{Account: *account, Client: cs.Client})
+	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: *account, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, account, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.ServiceAccount, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -812,7 +811,7 @@ func (cs *Changeset) deleteRole(ctx context.Context, tr *ChangesetResource, name
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, role, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.Role, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -822,11 +821,11 @@ func (cs *Changeset) deleteClusterRole(ctx context.Context, tr *ChangesetResourc
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewClusterRoleControl(ClusterRoleConfig{Role: *role, Client: cs.Client})
+	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: *role, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, role, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.ClusterRole, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -836,11 +835,11 @@ func (cs *Changeset) deleteRoleBinding(ctx context.Context, tr *ChangesetResourc
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewRoleBindingControl(RoleBindingConfig{Binding: *binding, Client: cs.Client})
+	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: *binding, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, binding, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.RoleBinding, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -850,11 +849,11 @@ func (cs *Changeset) deleteClusterRoleBinding(ctx context.Context, tr *Changeset
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{Binding: *binding, Client: cs.Client})
+	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: *binding, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, binding, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.ClusterRoleBinding, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -864,11 +863,11 @@ func (cs *Changeset) deletePodSecurityPolicy(ctx context.Context, tr *ChangesetR
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{Policy: *policy, Client: cs.Client})
+	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: *policy, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return cs.withDeleteOp(ctx, tr, policy, func() error {
+	return cs.withDeleteOp(ctx, tr, &control.PodSecurityPolicy, func() error {
 		return control.Delete(ctx, cascade)
 	})
 }
@@ -883,7 +882,7 @@ func (cs *Changeset) revert(ctx context.Context, item *ChangesetItem, info *Oper
 	case KindJob:
 		return cs.revertJob(ctx, item)
 	case KindReplicationController:
-		return cs.revertRC(ctx, item)
+		return cs.revertReplicationController(ctx, item)
 	case KindDeployment:
 		return cs.revertDeployment(ctx, item)
 	case KindService:
@@ -909,74 +908,70 @@ func (cs *Changeset) revert(ctx context.Context, item *ChangesetItem, info *Oper
 }
 
 func (cs *Changeset) revertDaemonSet(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	daemonSet, err := ParseDaemonSet(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewDSControl(DSConfig{DaemonSet: *daemonSet, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created daemon set, so we will delete it
 	if len(item.From) == 0 {
-		control, err := NewDSControl(DSConfig{Reader: strings.NewReader(item.To), Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
-	}
-	// this operation either created or updated daemon set, so we create a new version
-	control, err := NewDSControl(DSConfig{Reader: strings.NewReader(item.From), Client: cs.Client})
-	if err != nil {
 		return trace.Wrap(err)
 	}
+	// this operation either created or updated daemon set, so we create a new version
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertStatefulSet(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	statefulSet, err := ParseStatefulSet(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: *statefulSet, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created statefulset, so we will delete it
 	if len(item.From) == 0 {
-		statefulSet, err := ParseStatefulSet(strings.NewReader(item.To))
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: statefulSet, Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return trace.Wrap(err)
 	}
 	// this operation either created or updated statefulset, so we create a new version
-	statefulSet, err := ParseStatefulSet(strings.NewReader(item.From))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: statefulSet, Client: cs.Client})
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertJob(ctx context.Context, item *ChangesetItem) error {
-	jobSource := item.From
-	if len(jobSource) == 0 {
-		jobSource = item.To
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
 	}
-
-	job, err := ParseJob(strings.NewReader(jobSource))
+	job, err := ParseJob(strings.NewReader(resource))
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewJobControl(JobConfig{Job: job, Clientset: cs.Client})
+	control, err := NewJobControl(JobConfig{Job: *job, Clientset: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
 	if len(item.From) == 0 {
 		// this operation created the job, so we will delete it
 		err = control.Delete(ctx, true)
@@ -984,315 +979,299 @@ func (cs *Changeset) revertJob(ctx context.Context, item *ChangesetItem) error {
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return trace.Wrap(err)
 	}
 	// this operation either created or updated the job, so we create a new version
 	return control.Upsert(ctx)
 }
 
-func (cs *Changeset) revertRC(ctx context.Context, item *ChangesetItem) error {
+func (cs *Changeset) revertReplicationController(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	rc, err := ParseReplicationController(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewRCControl(RCConfig{ReplicationController: *rc, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created RC, so we will delete it
 	if len(item.From) == 0 {
-		control, err := NewRCControl(RCConfig{Reader: strings.NewReader(item.To), Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
-	}
-	// this operation either created or updated RC, so we create a new version
-	control, err := NewRCControl(RCConfig{Reader: strings.NewReader(item.From), Client: cs.Client})
-	if err != nil {
 		return trace.Wrap(err)
 	}
+	// this operation either created or updated RC, so we create a new version
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertDeployment(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	deployment, err := ParseDeployment(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewDeploymentControl(DeploymentConfig{Deployment: *deployment, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created Deployment, so we will delete it
 	if len(item.From) == 0 {
-		control, err := NewDeploymentControl(DeploymentConfig{Reader: strings.NewReader(item.To), Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
-	}
-	// this operation either created or updated Deployment, so we create a new version
-	control, err := NewDeploymentControl(DeploymentConfig{Reader: strings.NewReader(item.From), Client: cs.Client})
-	if err != nil {
 		return trace.Wrap(err)
 	}
+	// this operation either created or updated Deployment, so we create a new version
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertService(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	svc, err := ParseService(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewServiceControl(ServiceConfig{Service: *svc, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created Service, so we will delete it
 	if len(item.From) == 0 {
-		control, err := NewServiceControl(ServiceConfig{Reader: strings.NewReader(item.To), Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
-	}
-	// this operation either created or updated Service, so we create a new version
-	control, err := NewServiceControl(ServiceConfig{Reader: strings.NewReader(item.From), Client: cs.Client})
-	if err != nil {
 		return trace.Wrap(err)
 	}
+	// this operation either created or updated Service, so we create a new version
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertConfigMap(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	configMap, err := ParseConfigMap(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: *configMap, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created ConfigMap, so we will delete it
 	if len(item.From) == 0 {
-		control, err := NewConfigMapControl(ConfigMapConfig{Reader: strings.NewReader(item.To), Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
-	}
-	// this operation either created or updated ConfigMap, so we create a new version
-	control, err := NewConfigMapControl(ConfigMapConfig{Reader: strings.NewReader(item.From), Client: cs.Client})
-	if err != nil {
 		return trace.Wrap(err)
 	}
+	// this operation either created or updated ConfigMap, so we create a new version
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertSecret(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	secret, err := ParseSecret(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewSecretControl(SecretConfig{Secret: *secret, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created Secret, so we will delete it
 	if len(item.From) == 0 {
-		control, err := NewSecretControl(SecretConfig{Reader: strings.NewReader(item.To), Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
-	}
-	// this operation either created or updated Secret, so we create a new version
-	control, err := NewSecretControl(SecretConfig{Reader: strings.NewReader(item.From), Client: cs.Client})
-	if err != nil {
 		return trace.Wrap(err)
 	}
+	// this operation either created or updated Secret, so we create a new version
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertServiceAccount(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	account, err := ParseServiceAccount(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: *account, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created the resource, so we will delete it
 	if len(item.From) == 0 {
-		account, err := ParseServiceAccount(strings.NewReader(item.To))
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		control, err := NewServiceAccountControl(ServiceAccountConfig{Account: *account, Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return trace.Wrap(err)
 	}
-
 	// this operation either created or updated the resource, so we create a new version
-	account, err := ParseServiceAccount(strings.NewReader(item.From))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	control, err := NewServiceAccountControl(ServiceAccountConfig{Account: *account, Client: cs.Client})
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertRole(ctx context.Context, item *ChangesetItem) error {
-	// this operation created the resource, so we will delete it
-	if len(item.From) == 0 {
-		role, err := ParseRole(strings.NewReader(item.To))
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		control, err := NewRoleControl(RoleConfig{Role: *role, Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		err = control.Delete(ctx, true)
-		// If the resource has already been deleted, suppress the error
-		if trace.IsNotFound(err) {
-			return nil
-		}
-		return err
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
 	}
-
-	// this operation either created or updated the resource, so we create a new version
-	role, err := ParseRole(strings.NewReader(item.From))
+	role, err := ParseRole(strings.NewReader(resource))
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
 	control, err := NewRoleControl(RoleConfig{Role: *role, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	// this operation created the resource, so we will delete it
+	if len(item.From) == 0 {
+		err = control.Delete(ctx, true)
+		// If the resource has already been deleted, suppress the error
+		if trace.IsNotFound(err) {
+			return nil
+		}
+		return trace.Wrap(err)
+	}
+	// this operation either created or updated the resource, so we create a new version
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertClusterRole(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	role, err := ParseClusterRole(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: *role, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created the resource, so we will delete it
 	if len(item.From) == 0 {
-		role, err := ParseClusterRole(strings.NewReader(item.To))
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		control, err := NewClusterRoleControl(ClusterRoleConfig{Role: *role, Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return trace.Wrap(err)
 	}
-
 	// this operation either created or updated the resource, so we create a new version
-	role, err := ParseClusterRole(strings.NewReader(item.From))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	control, err := NewClusterRoleControl(ClusterRoleConfig{Role: *role, Client: cs.Client})
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertRoleBinding(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	binding, err := ParseRoleBinding(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: *binding, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created the resource, so we will delete it
 	if len(item.From) == 0 {
-		binding, err := ParseRoleBinding(strings.NewReader(item.To))
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		control, err := NewRoleBindingControl(RoleBindingConfig{Binding: *binding, Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return trace.Wrap(err)
 	}
-
 	// this operation either created or updated the resource, so we create a new version
-	binding, err := ParseRoleBinding(strings.NewReader(item.From))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	control, err := NewRoleBindingControl(RoleBindingConfig{Binding: *binding, Client: cs.Client})
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertClusterRoleBinding(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	binding, err := ParseClusterRoleBinding(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: *binding, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created the resource, so we will delete it
 	if len(item.From) == 0 {
-		binding, err := ParseClusterRoleBinding(strings.NewReader(item.To))
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{Binding: *binding, Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return trace.Wrap(err)
 	}
-
 	// this operation either created or updated the resource, so we create a new version
-	binding, err := ParseClusterRoleBinding(strings.NewReader(item.From))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{Binding: *binding, Client: cs.Client})
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	return control.Upsert(ctx)
 }
 
 func (cs *Changeset) revertPodSecurityPolicy(ctx context.Context, item *ChangesetItem) error {
+	resource := item.From
+	if len(resource) == 0 {
+		resource = item.To
+	}
+	psp, err := ParsePodSecurityPolicy(strings.NewReader(resource))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: *psp, Client: cs.Client})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// this operation created the resource, so we will delete it
 	if len(item.From) == 0 {
-		policy, err := ParsePodSecurityPolicy(strings.NewReader(item.To))
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{Policy: *policy, Client: cs.Client})
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		err = control.Delete(ctx, true)
 		// If the resource has already been deleted, suppress the error
 		if trace.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return trace.Wrap(err)
 	}
-
 	// this operation either created or updated the resource, so we create a new version
-	policy, err := ParsePodSecurityPolicy(strings.NewReader(item.From))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{Policy: *policy, Client: cs.Client})
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	return control.Upsert(ctx)
 }
 
-func (cs *Changeset) withUpsertOp(ctx context.Context, tr *ChangesetResource, old metav1.Object, new metav1.Object, fn func() error) (*ChangesetResource, error) {
+func (cs *Changeset) withUpsertOp(ctx context.Context, tr *ChangesetResource, old, new metav1.Object, fn func() error) (*ChangesetResource, error) {
 	to, err := goyaml.Marshal(new)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1334,80 +1313,87 @@ func (cs *Changeset) upsertJob(ctx context.Context, tr *ChangesetResource, data 
 	log.Infof("upsert job %v", formatMeta(job.ObjectMeta))
 
 	jobs := cs.Client.Batch().Jobs(job.Namespace)
-	currentJob, err := jobs.Get(job.Name, metav1.GetOptions{})
+	current, err := jobs.Get(job.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Info("existing job not found")
-		currentJob = nil
+		current = nil
 	}
-
-	control, err := NewJobControl(JobConfig{Job: job, Clientset: cs.Client})
+	control, err := NewJobControl(JobConfig{Job: *job, Clientset: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentJob, job, func() error {
+	if current != nil {
+		updateTypeMetaJob(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.Job, func() error {
 		return control.Upsert(ctx)
 	})
 }
 
 func (cs *Changeset) upsertDaemonSet(ctx context.Context, tr *ChangesetResource, data []byte) (*ChangesetResource, error) {
-	ds, err := ParseDaemonSet(bytes.NewReader(data))
+	daemonSet, err := ParseDaemonSet(bytes.NewReader(data))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	log := log.WithFields(log.Fields{
 		"cs": tr.String(),
-		"ds": fmt.Sprintf("%v/%v", ds.Namespace, ds.Name),
+		"ds": fmt.Sprintf("%v/%v", daemonSet.Namespace, daemonSet.Name),
 	})
-	log.Infof("upsert daemon set %v", formatMeta(ds.ObjectMeta))
-	daemons := cs.Client.AppsV1().DaemonSets(ds.Namespace)
-	currentDS, err := daemons.Get(ds.Name, metav1.GetOptions{})
+	log.Infof("upsert daemon set %v", formatMeta(daemonSet.ObjectMeta))
+	daemons := cs.Client.AppsV1().DaemonSets(daemonSet.Namespace)
+	current, err := daemons.Get(daemonSet.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing daemonset not found")
-		currentDS = nil
+		current = nil
 	}
-	control, err := NewDSControl(DSConfig{DaemonSet: ds, Client: cs.Client})
+	control, err := NewDSControl(DSConfig{DaemonSet: *daemonSet, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentDS, ds, func() error {
+	if current != nil {
+		updateTypeMetaDaemonset(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.DaemonSet, func() error {
 		return control.Upsert(ctx)
 	})
 }
 
 func (cs *Changeset) upsertStatefulSet(ctx context.Context, tr *ChangesetResource, data []byte) (*ChangesetResource, error) {
-	ss, err := ParseStatefulSet(bytes.NewReader(data))
+	statefulSet, err := ParseStatefulSet(bytes.NewReader(data))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	log := log.WithFields(log.Fields{
 		"cs":          tr.String(),
-		"statefulset": fmt.Sprintf("%v/%v", ss.Namespace, ss.Name),
+		"statefulset": fmt.Sprintf("%v/%v", statefulSet.Namespace, statefulSet.Name),
 	})
-	log.Infof("upsert statefulset %v", formatMeta(ss.ObjectMeta))
-	statefulsets := cs.Client.AppsV1().StatefulSets(ss.Namespace)
-	currentSS, err := statefulsets.Get(ss.Name, metav1.GetOptions{})
+	log.Infof("upsert statefulset %v", formatMeta(statefulSet.ObjectMeta))
+	statefulsets := cs.Client.AppsV1().StatefulSets(statefulSet.Namespace)
+	current, err := statefulsets.Get(statefulSet.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing statefulset not found")
-		currentSS = nil
+		current = nil
 	}
-	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: ss, Client: cs.Client})
+	control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: *statefulSet, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	return cs.withUpsertOp(ctx, tr, currentSS, ss, func() error {
+	if current != nil {
+		updateTypeMetaStatefulSet(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.StatefulSet, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1423,20 +1409,23 @@ func (cs *Changeset) upsertRC(ctx context.Context, tr *ChangesetResource, data [
 	})
 	log.Infof("upsert replication controller %v", formatMeta(rc.ObjectMeta))
 	rcs := cs.Client.Core().ReplicationControllers(rc.Namespace)
-	currentRC, err := rcs.Get(rc.Name, metav1.GetOptions{})
+	current, err := rcs.Get(rc.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing replication controller not found")
-		currentRC = nil
+		current = nil
 	}
-	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
+	control, err := NewRCControl(RCConfig{ReplicationController: *rc, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentRC, rc, func() error {
+	if current != nil {
+		updateTypeMetaReplicationController(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.ReplicationController, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1451,21 +1440,24 @@ func (cs *Changeset) upsertDeployment(ctx context.Context, tr *ChangesetResource
 		"deployment": fmt.Sprintf("%v/%v", deployment.Namespace, deployment.Name),
 	})
 	log.Infof("upsert deployment %v", formatMeta(deployment.ObjectMeta))
-	deployments := cs.Client.Extensions().Deployments(deployment.Namespace)
-	currentDeployment, err := deployments.Get(deployment.Name, metav1.GetOptions{})
+	deployments := cs.Client.AppsV1().Deployments(deployment.Namespace)
+	current, err := deployments.Get(deployment.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing deployment not found")
-		currentDeployment = nil
+		current = nil
 	}
-	control, err := NewDeploymentControl(DeploymentConfig{Deployment: deployment, Client: cs.Client})
+	control, err := NewDeploymentControl(DeploymentConfig{Deployment: *deployment, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentDeployment, deployment, func() error {
+	if current != nil {
+		updateTypeMetaDeployment(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.Deployment, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1481,20 +1473,23 @@ func (cs *Changeset) upsertService(ctx context.Context, tr *ChangesetResource, d
 	})
 	log.Infof("upsert service %v", formatMeta(service.ObjectMeta))
 	services := cs.Client.Core().Services(service.Namespace)
-	currentService, err := services.Get(service.Name, metav1.GetOptions{})
+	current, err := services.Get(service.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing service not found")
-		currentService = nil
+		current = nil
 	}
-	control, err := NewServiceControl(ServiceConfig{Service: service, Client: cs.Client})
+	control, err := NewServiceControl(ServiceConfig{Service: *service, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentService, service, func() error {
+	if current != nil {
+		updateTypeMetaService(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.Service, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1509,20 +1504,23 @@ func (cs *Changeset) upsertServiceAccount(ctx context.Context, tr *ChangesetReso
 		"service_account": formatMeta(account.ObjectMeta),
 	})
 	accounts := cs.Client.Core().ServiceAccounts(account.Namespace)
-	currentAccount, err := accounts.Get(account.Name, metav1.GetOptions{})
+	current, err := accounts.Get(account.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing service account not found")
-		currentAccount = nil
+		current = nil
 	}
-	control, err := NewServiceAccountControl(ServiceAccountConfig{Account: *account, Client: cs.Client})
+	control, err := NewServiceAccountControl(ServiceAccountConfig{ServiceAccount: *account, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentAccount, account, func() error {
+	if current != nil {
+		updateTypeMetaServiceAccount(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.ServiceAccount, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1537,20 +1535,23 @@ func (cs *Changeset) upsertRole(ctx context.Context, tr *ChangesetResource, data
 		"role": formatMeta(role.ObjectMeta),
 	})
 	roles := cs.Client.RbacV1().Roles(role.Namespace)
-	currentRole, err := roles.Get(role.Name, metav1.GetOptions{})
+	current, err := roles.Get(role.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing role not found")
-		currentRole = nil
+		current = nil
 	}
 	control, err := NewRoleControl(RoleConfig{Role: *role, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentRole, role, func() error {
+	if current != nil {
+		updateTypeMetaRole(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.Role, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1565,20 +1566,23 @@ func (cs *Changeset) upsertClusterRole(ctx context.Context, tr *ChangesetResourc
 		"cluster_role": formatMeta(role.ObjectMeta),
 	})
 	roles := cs.Client.RbacV1().ClusterRoles()
-	currentRole, err := roles.Get(role.Name, metav1.GetOptions{})
+	current, err := roles.Get(role.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing cluster role not found")
-		currentRole = nil
+		current = nil
 	}
-	control, err := NewClusterRoleControl(ClusterRoleConfig{Role: *role, Client: cs.Client})
+	control, err := NewClusterRoleControl(ClusterRoleConfig{ClusterRole: *role, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentRole, role, func() error {
+	if current != nil {
+		updateTypeMetaClusterRole(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.ClusterRole, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1593,20 +1597,23 @@ func (cs *Changeset) upsertRoleBinding(ctx context.Context, tr *ChangesetResourc
 		"role_binding": formatMeta(binding.ObjectMeta),
 	})
 	bindings := cs.Client.RbacV1().RoleBindings(binding.Namespace)
-	currentBinding, err := bindings.Get(binding.Name, metav1.GetOptions{})
+	current, err := bindings.Get(binding.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing role binding not found")
-		currentBinding = nil
+		current = nil
 	}
-	control, err := NewRoleBindingControl(RoleBindingConfig{Binding: *binding, Client: cs.Client})
+	control, err := NewRoleBindingControl(RoleBindingConfig{RoleBinding: *binding, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentBinding, binding, func() error {
+	if current != nil {
+		updateTypeMetaRoleBinding(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.RoleBinding, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1617,24 +1624,27 @@ func (cs *Changeset) upsertClusterRoleBinding(ctx context.Context, tr *Changeset
 		return nil, trace.Wrap(err)
 	}
 	log := log.WithFields(log.Fields{
-		"cs": tr.String(),
+		"cs":                   tr.String(),
 		"cluster_role_binding": formatMeta(binding.ObjectMeta),
 	})
 	bindings := cs.Client.RbacV1().ClusterRoleBindings()
-	currentBinding, err := bindings.Get(binding.Name, metav1.GetOptions{})
+	current, err := bindings.Get(binding.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing cluster role binding not found")
-		currentBinding = nil
+		current = nil
 	}
-	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{Binding: *binding, Client: cs.Client})
+	control, err := NewClusterRoleBindingControl(ClusterRoleBindingConfig{ClusterRoleBinding: *binding, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentBinding, binding, func() error {
+	if current != nil {
+		updateTypeMetaClusterRoleBinding(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.ClusterRoleBinding, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1645,24 +1655,27 @@ func (cs *Changeset) upsertPodSecurityPolicy(ctx context.Context, tr *ChangesetR
 		return nil, trace.Wrap(err)
 	}
 	log := log.WithFields(log.Fields{
-		"cs": tr.String(),
+		"cs":                  tr.String(),
 		"pod_security_policy": formatMeta(policy.ObjectMeta),
 	})
 	policies := cs.Client.ExtensionsV1beta1().PodSecurityPolicies()
-	currentPolicy, err := policies.Get(policy.Name, metav1.GetOptions{})
+	current, err := policies.Get(policy.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing pod security policy not found")
-		currentPolicy = nil
+		current = nil
 	}
-	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{Policy: *policy, Client: cs.Client})
+	control, err := NewPodSecurityPolicyControl(PodSecurityPolicyConfig{PodSecurityPolicy: *policy, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentPolicy, policy, func() error {
+	if current != nil {
+		updateTypeMetaPodSecurityPolicy(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.PodSecurityPolicy, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1678,20 +1691,23 @@ func (cs *Changeset) upsertConfigMap(ctx context.Context, tr *ChangesetResource,
 	})
 	log.Infof("upsert configmap %v", formatMeta(configMap.ObjectMeta))
 	configMaps := cs.Client.Core().ConfigMaps(configMap.Namespace)
-	currentConfigMap, err := configMaps.Get(configMap.Name, metav1.GetOptions{})
+	current, err := configMaps.Get(configMap.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing configmap not found")
-		currentConfigMap = nil
+		current = nil
 	}
-	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: configMap, Client: cs.Client})
+	control, err := NewConfigMapControl(ConfigMapConfig{ConfigMap: *configMap, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentConfigMap, configMap, func() error {
+	if current != nil {
+		updateTypeMetaConfigMap(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.ConfigMap, func() error {
 		return control.Upsert(ctx)
 	})
 }
@@ -1707,20 +1723,23 @@ func (cs *Changeset) upsertSecret(ctx context.Context, tr *ChangesetResource, da
 	})
 	log.Infof("upsert secret %v", formatMeta(secret.ObjectMeta))
 	secrets := cs.Client.Core().Secrets(secret.Namespace)
-	currentSecret, err := secrets.Get(secret.Name, metav1.GetOptions{})
+	current, err := secrets.Get(secret.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 		log.Debug("existing secret not found")
-		currentSecret = nil
+		current = nil
 	}
-	control, err := NewSecretControl(SecretConfig{Secret: secret, Client: cs.Client})
+	control, err := NewSecretControl(SecretConfig{Secret: *secret, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return cs.withUpsertOp(ctx, tr, currentSecret, secret, func() error {
+	if current != nil {
+		updateTypeMetaSecret(current)
+	}
+	return cs.withUpsertOp(ctx, tr, current, &control.Secret, func() error {
 		return control.Upsert(ctx)
 	})
 }

--- a/changeset.go
+++ b/changeset.go
@@ -371,7 +371,7 @@ func (cs *Changeset) statusDaemonSet(ctx context.Context, data []byte, uid strin
 			return trace.NotFound("daemonset with UID %v not found", uid)
 		}
 	}
-	control, err := NewDSControl(DSConfig{DaemonSet: daemonset, Client: cs.Client})
+	control, err := NewDaemonSetControl(DSConfig{DaemonSet: daemonset, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -435,7 +435,7 @@ func (cs *Changeset) statusRC(ctx context.Context, data []byte, uid string) erro
 			return trace.NotFound("replication controller with UID %v not found", uid)
 		}
 	}
-	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
+	control, err := NewReplicationControllerControl(RCConfig{ReplicationController: rc, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -681,7 +681,7 @@ func (cs *Changeset) deleteDaemonSet(ctx context.Context, tr *ChangesetResource,
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewDSControl(DSConfig{DaemonSet: daemonSet, Client: cs.Client})
+	control, err := NewDaemonSetControl(DSConfig{DaemonSet: daemonSet, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -723,7 +723,7 @@ func (cs *Changeset) deleteRC(ctx context.Context, tr *ChangesetResource, namesp
 	if err != nil {
 		return ConvertError(err)
 	}
-	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
+	control, err := NewReplicationControllerControl(RCConfig{ReplicationController: rc, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -916,7 +916,7 @@ func (cs *Changeset) revertDaemonSet(ctx context.Context, item *ChangesetItem) e
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewDSControl(DSConfig{DaemonSet: daemonSet, Client: cs.Client})
+	control, err := NewDaemonSetControl(DSConfig{DaemonSet: daemonSet, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -994,7 +994,7 @@ func (cs *Changeset) revertReplicationController(ctx context.Context, item *Chan
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
+	control, err := NewReplicationControllerControl(RCConfig{ReplicationController: rc, Client: cs.Client})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1354,7 +1354,7 @@ func (cs *Changeset) upsertDaemonSet(ctx context.Context, tr *ChangesetResource,
 		log.Debug("existing daemonset not found")
 		current = nil
 	}
-	control, err := NewDSControl(DSConfig{DaemonSet: daemonSet, Client: cs.Client})
+	control, err := NewDaemonSetControl(DSConfig{DaemonSet: daemonSet, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1418,7 +1418,7 @@ func (cs *Changeset) upsertRC(ctx context.Context, tr *ChangesetResource, data [
 		log.Debug("existing replication controller not found")
 		current = nil
 	}
-	control, err := NewRCControl(RCConfig{ReplicationController: rc, Client: cs.Client})
+	control, err := NewReplicationControllerControl(RCConfig{ReplicationController: rc, Client: cs.Client})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/configmap.go
+++ b/configmap.go
@@ -41,16 +41,19 @@ func NewConfigMapControl(config ConfigMapConfig) (*ConfigMapControl, error) {
 // ConfigMapConfig  is a ConfigMap control configuration
 type ConfigMapConfig struct {
 	// ConfigMap is already parsed daemon set, will be used if present
-	v1.ConfigMap
+	*v1.ConfigMap
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
 func (c *ConfigMapConfig) checkAndSetDefaults() error {
+	if c.ConfigMap == nil {
+		return trace.BadParameter("missing parameter ConfigMap")
+	}
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	updateTypeMetaConfigMap(&c.ConfigMap)
+	updateTypeMetaConfigMap(c.ConfigMap)
 	return nil
 }
 
@@ -81,10 +84,10 @@ func (c *ConfigMapControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = configMaps.Create(&c.ConfigMap)
+		_, err = configMaps.Create(c.ConfigMap)
 		return ConvertError(err)
 	}
-	_, err = configMaps.Update(&c.ConfigMap)
+	_, err = configMaps.Update(c.ConfigMap)
 	return ConvertError(err)
 }
 

--- a/configmap.go
+++ b/configmap.go
@@ -16,57 +16,41 @@ package rigging
 
 import (
 	"context"
-	"io"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
-	"k8s.io/api/core/v1"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 // NewConfigMapControl returns new instance of ConfigMap updater
 func NewConfigMapControl(config ConfigMapConfig) (*ConfigMapControl, error) {
-	err := config.CheckAndSetDefaults()
+	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var rc *v1.ConfigMap
-	if config.ConfigMap != nil {
-		rc = config.ConfigMap
-	} else {
-		rc, err = ParseConfigMap(config.Reader)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-	rc.Kind = KindConfigMap
 	return &ConfigMapControl{
 		ConfigMapConfig: config,
-		configMap:       *rc,
 		Entry: log.WithFields(log.Fields{
-			"configMap": formatMeta(rc.ObjectMeta),
+			"configMap": formatMeta(config.ObjectMeta),
 		}),
 	}, nil
 }
 
 // ConfigMapConfig  is a ConfigMap control configuration
 type ConfigMapConfig struct {
-	// Reader with daemon set to update, will be used if present
-	Reader io.Reader
 	// ConfigMap is already parsed daemon set, will be used if present
-	ConfigMap *v1.ConfigMap
+	v1.ConfigMap
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
-func (c *ConfigMapConfig) CheckAndSetDefaults() error {
-	if c.Reader == nil && c.ConfigMap == nil {
-		return trace.BadParameter("missing parameter Reader or ConfigMap")
-	}
+func (c *ConfigMapConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
+	updateTypeMetaConfigMap(&c.ConfigMap)
 	return nil
 }
 
@@ -74,39 +58,45 @@ func (c *ConfigMapConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type ConfigMapControl struct {
 	ConfigMapConfig
-	configMap v1.ConfigMap
 	*log.Entry
 }
 
 func (c *ConfigMapControl) Delete(ctx context.Context, cascade bool) error {
-	c.Infof("delete %v", formatMeta(c.configMap.ObjectMeta))
+	c.Infof("delete %v", formatMeta(c.ConfigMap.ObjectMeta))
 
-	err := c.Client.Core().ConfigMaps(c.configMap.Namespace).Delete(c.configMap.Name, nil)
+	err := c.Client.Core().ConfigMaps(c.ConfigMap.Namespace).Delete(c.ConfigMap.Name, nil)
 	return ConvertError(err)
 }
 
 func (c *ConfigMapControl) Upsert(ctx context.Context) error {
-	c.Infof("upsert %v", formatMeta(c.configMap.ObjectMeta))
+	c.Infof("upsert %v", formatMeta(c.ConfigMap.ObjectMeta))
 
-	configMaps := c.Client.Core().ConfigMaps(c.configMap.Namespace)
-	c.configMap.UID = ""
-	c.configMap.SelfLink = ""
-	c.configMap.ResourceVersion = ""
-	_, err := configMaps.Get(c.configMap.Name, metav1.GetOptions{})
+	configMaps := c.Client.Core().ConfigMaps(c.ConfigMap.Namespace)
+	c.ConfigMap.UID = ""
+	c.ConfigMap.SelfLink = ""
+	c.ConfigMap.ResourceVersion = ""
+	_, err := configMaps.Get(c.ConfigMap.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = configMaps.Create(&c.configMap)
+		_, err = configMaps.Create(&c.ConfigMap)
 		return ConvertError(err)
 	}
-	_, err = configMaps.Update(&c.configMap)
+	_, err = configMaps.Update(&c.ConfigMap)
 	return ConvertError(err)
 }
 
 func (c *ConfigMapControl) Status() error {
-	configMaps := c.Client.Core().ConfigMaps(c.configMap.Namespace)
-	_, err := configMaps.Get(c.configMap.Name, metav1.GetOptions{})
+	configMaps := c.Client.Core().ConfigMaps(c.ConfigMap.Namespace)
+	_, err := configMaps.Get(c.ConfigMap.Name, metav1.GetOptions{})
 	return ConvertError(err)
+}
+
+func updateTypeMetaConfigMap(r *v1.ConfigMap) {
+	r.Kind = KindConfigMap
+	if r.APIVersion == "" {
+		r.APIVersion = v1.SchemeGroupVersion.String()
+	}
 }

--- a/configmapgen.go
+++ b/configmapgen.go
@@ -34,7 +34,7 @@ func GenerateConfigMap(name string, namespace string, fromFile []string, fromLit
 	configMap := &v1.ConfigMap{}
 	configMap.Name = name
 	configMap.Kind = KindConfigMap
-	configMap.APIVersion = V1
+	configMap.APIVersion = v1.SchemeGroupVersion.String()
 	configMap.Namespace = namespace
 	configMap.Data = map[string]string{}
 	if err := handleConfigMapFromFileSources(configMap, fromFile); err != nil {

--- a/configmapgen_test.go
+++ b/configmapgen_test.go
@@ -30,7 +30,7 @@ func (s *ConfigmapGenSuite) TestConfigMap(c *C) {
 			namespace: "kube-system",
 			literals:  []string{"a=b", "key=val"},
 			result: &v1.ConfigMap{
-				TypeMeta:   metav1.TypeMeta{Kind: KindConfigMap, APIVersion: V1},
+				TypeMeta:   metav1.TypeMeta{Kind: KindConfigMap, APIVersion: v1.SchemeGroupVersion.String()},
 				ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: "kube-system"},
 				Data: map[string]string{
 					"a":   "b",
@@ -43,7 +43,7 @@ func (s *ConfigmapGenSuite) TestConfigMap(c *C) {
 			namespace: "kube-system",
 			files:     files(c, []file{{name: "file1", value: "val1"}, {name: "text.yaml", value: "a: b"}}),
 			result: &v1.ConfigMap{
-				TypeMeta:   metav1.TypeMeta{Kind: KindConfigMap, APIVersion: V1},
+				TypeMeta:   metav1.TypeMeta{Kind: KindConfigMap, APIVersion: v1.SchemeGroupVersion.String()},
 				ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: "kube-system"},
 				Data: map[string]string{
 					"file1":     "val1",

--- a/constants.go
+++ b/constants.go
@@ -45,11 +45,7 @@ const (
 	DefaultRetryPeriod = time.Second
 	DefaultBufferSize  = 1024
 
-	ChangesetAPIVersion  = "changeset.gravitational.io/v1"
-	BatchAPIVersion      = "batch/v1"
-	RBACAPIVersion       = "rbac.authorization.k8s.io/v1alpha1"
-	ExtensionsAPIVersion = "extensions/v1beta1"
-	V1                   = "v1"
+	ChangesetAPIVersion = "changeset.gravitational.io/v1"
 )
 
 // NamespaceOrDefault returns a default namespace if the specified namespace is empty

--- a/deployment.go
+++ b/deployment.go
@@ -44,16 +44,19 @@ func NewDeploymentControl(config DeploymentConfig) (*DeploymentControl, error) {
 // DeploymentConfig  is a Deployment control configuration
 type DeploymentConfig struct {
 	// Deployment is already parsed deployment, will be used if present
-	appsv1.Deployment
+	*appsv1.Deployment
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
 func (c *DeploymentConfig) checkAndSetDefaults() error {
+	if c.Deployment == nil {
+		return trace.BadParameter("missing parameter Deployment")
+	}
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	updateTypeMetaDeployment(&c.Deployment)
+	updateTypeMetaDeployment(c.Deployment)
 	return nil
 }
 
@@ -125,10 +128,10 @@ func (c *DeploymentControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = deployments.Create(&c.Deployment)
+		_, err = deployments.Create(c.Deployment)
 		return ConvertError(err)
 	}
-	_, err = deployments.Update(&c.Deployment)
+	_, err = deployments.Update(c.Deployment)
 	return ConvertError(err)
 }
 

--- a/deployment.go
+++ b/deployment.go
@@ -16,12 +16,12 @@ package rigging
 
 import (
 	"context"
-	"io"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -29,46 +29,31 @@ import (
 
 // NewDeploymentControl returns new instance of Deployment updater
 func NewDeploymentControl(config DeploymentConfig) (*DeploymentControl, error) {
-	err := config.CheckAndSetDefaults()
+	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var rc *appsv1.Deployment
-	if config.Deployment != nil {
-		rc = config.Deployment
-	} else {
-		rc, err = ParseDeployment(config.Reader)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-	rc.Kind = KindDeployment
 	return &DeploymentControl{
 		DeploymentConfig: config,
-		deployment:       *rc,
-		Entry: log.WithFields(log.Fields{
-			"deployment": formatMeta(rc.ObjectMeta),
+		FieldLogger: log.WithFields(log.Fields{
+			"deployment": formatMeta(config.ObjectMeta),
 		}),
 	}, nil
 }
 
 // DeploymentConfig  is a Deployment control configuration
 type DeploymentConfig struct {
-	// Reader with deployment to update, will be used if present
-	Reader io.Reader
 	// Deployment is already parsed deployment, will be used if present
-	Deployment *appsv1.Deployment
+	appsv1.Deployment
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
-func (c *DeploymentConfig) CheckAndSetDefaults() error {
-	if c.Reader == nil && c.Deployment == nil {
-		return trace.BadParameter("missing parameter Reader or Deployment")
-	}
+func (c *DeploymentConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
+	updateTypeMetaDeployment(&c.Deployment)
 	return nil
 }
 
@@ -76,20 +61,19 @@ func (c *DeploymentConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type DeploymentControl struct {
 	DeploymentConfig
-	deployment appsv1.Deployment
-	*log.Entry
+	log.FieldLogger
 }
 
 func (c *DeploymentControl) Delete(ctx context.Context, cascade bool) error {
-	c.Infof("delete %v", formatMeta(c.deployment.ObjectMeta))
+	c.Infof("delete %v", formatMeta(c.Deployment.ObjectMeta))
 
-	deployments := c.Client.Apps().Deployments(c.deployment.Namespace)
-	currentDeployment, err := deployments.Get(c.deployment.Name, metav1.GetOptions{})
+	deployments := c.Client.AppsV1().Deployments(c.Deployment.Namespace)
+	currentDeployment, err := deployments.Get(c.Deployment.Name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
 
-	pods := c.Client.Core().Pods(c.deployment.Namespace)
+	pods := c.Client.Core().Pods(c.Deployment.Namespace)
 	currentPods, err := c.collectPods(currentDeployment)
 	if err != nil {
 		return trace.Wrap(err)
@@ -105,7 +89,7 @@ func (c *DeploymentControl) Delete(ctx context.Context, cascade bool) error {
 		}
 	}
 	deletePolicy := metav1.DeletePropagationForeground
-	err = deployments.Delete(c.deployment.Name, &metav1.DeleteOptions{
+	err = deployments.Delete(c.Deployment.Name, &metav1.DeleteOptions{
 		PropagationPolicy: &deletePolicy,
 	})
 	if err != nil {
@@ -113,7 +97,7 @@ func (c *DeploymentControl) Delete(ctx context.Context, cascade bool) error {
 	}
 
 	err = waitForObjectDeletion(func() error {
-		_, err := deployments.Get(c.deployment.Name, metav1.GetOptions{})
+		_, err := deployments.Get(c.Deployment.Name, metav1.GetOptions{})
 		return ConvertError(err)
 	})
 	if err != nil {
@@ -121,7 +105,7 @@ func (c *DeploymentControl) Delete(ctx context.Context, cascade bool) error {
 	}
 
 	// wait until all Pods have been cleaned up
-	err = waitForPods(pods, currentPods, *c.Entry)
+	err = waitForPods(pods, currentPods)
 	if err != nil {
 		c.Warningf("failed to wait for Pods to clean up: %v", trace.DebugReport(err))
 	}
@@ -129,36 +113,36 @@ func (c *DeploymentControl) Delete(ctx context.Context, cascade bool) error {
 }
 
 func (c *DeploymentControl) Upsert(ctx context.Context) error {
-	c.Infof("upsert %v", formatMeta(c.deployment.ObjectMeta))
+	c.Infof("upsert %v", formatMeta(c.Deployment.ObjectMeta))
 
-	deployments := c.Client.Apps().Deployments(c.deployment.Namespace)
-	c.deployment.UID = ""
-	c.deployment.SelfLink = ""
-	c.deployment.ResourceVersion = ""
-	_, err := deployments.Get(c.deployment.Name, metav1.GetOptions{})
+	deployments := c.Client.AppsV1().Deployments(c.Deployment.Namespace)
+	c.Deployment.UID = ""
+	c.Deployment.SelfLink = ""
+	c.Deployment.ResourceVersion = ""
+	_, err := deployments.Get(c.Deployment.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = deployments.Create(&c.deployment)
+		_, err = deployments.Create(&c.Deployment)
 		return ConvertError(err)
 	}
-	_, err = deployments.Update(&c.deployment)
+	_, err = deployments.Update(&c.Deployment)
 	return ConvertError(err)
 }
 
 func (c *DeploymentControl) nodeSelector() labels.Selector {
 	set := make(labels.Set)
-	for key, val := range c.deployment.Spec.Template.Spec.NodeSelector {
+	for key, val := range c.Deployment.Spec.Template.Spec.NodeSelector {
 		set[key] = val
 	}
 	return set.AsSelector()
 }
 
 func (c *DeploymentControl) Status() error {
-	deployments := c.Client.Extensions().Deployments(c.deployment.Namespace)
-	currentDeployment, err := deployments.Get(c.deployment.Name, metav1.GetOptions{})
+	deployments := c.Client.Extensions().Deployments(c.Deployment.Namespace)
+	currentDeployment, err := deployments.Get(c.Deployment.Name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
@@ -166,7 +150,7 @@ func (c *DeploymentControl) Status() error {
 	if currentDeployment.Spec.Replicas != nil {
 		replicas = *(currentDeployment.Spec.Replicas)
 	}
-	deployment := formatMeta(c.deployment.ObjectMeta)
+	deployment := formatMeta(c.Deployment.ObjectMeta)
 	if currentDeployment.Status.UpdatedReplicas != replicas {
 		return trace.CompareFailed("deployment %v not successful: expected replicas: %v, updated: %v",
 			deployment, replicas, currentDeployment.Status.UpdatedReplicas)
@@ -183,8 +167,15 @@ func (c *DeploymentControl) collectPods(deployment *appsv1.Deployment) (map[stri
 	if deployment.Spec.Selector != nil {
 		labels = deployment.Spec.Selector.MatchLabels
 	}
-	pods, err := CollectPods(deployment.Namespace, labels, c.Entry, c.Client, func(ref metav1.OwnerReference) bool {
+	pods, err := CollectPods(deployment.Namespace, labels, c.FieldLogger, c.Client, func(ref metav1.OwnerReference) bool {
 		return ref.Kind == KindDeployment && ref.UID == deployment.UID
 	})
 	return pods, ConvertError(err)
+}
+
+func updateTypeMetaDeployment(r *appsv1.Deployment) {
+	r.Kind = KindDeployment
+	if r.APIVersion == "" {
+		r.APIVersion = v1beta1.SchemeGroupVersion.String()
+	}
 }

--- a/deployment.go
+++ b/deployment.go
@@ -43,7 +43,7 @@ func NewDeploymentControl(config DeploymentConfig) (*DeploymentControl, error) {
 
 // DeploymentConfig  is a Deployment control configuration
 type DeploymentConfig struct {
-	// Deployment is already parsed deployment, will be used if present
+	// Deployment specifies the existing deployment
 	*appsv1.Deployment
 	// Client is k8s client
 	Client *kubernetes.Clientset

--- a/ds.go
+++ b/ds.go
@@ -16,12 +16,11 @@ package rigging
 
 import (
 	"context"
-	"io"
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -30,47 +29,31 @@ import (
 
 // NewDSControl returns new instance of DaemonSet updater
 func NewDSControl(config DSConfig) (*DSControl, error) {
-	err := config.CheckAndSetDefaults()
+	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var ds *appsv1.DaemonSet
-	if config.DaemonSet != nil {
-		ds = config.DaemonSet
-	} else {
-		ds, err = ParseDaemonSet(config.Reader)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-	// sometimes existing objects pulled from the API don't have type set
-	ds.Kind = KindDaemonSet
 	return &DSControl{
-		DSConfig:  config,
-		daemonSet: *ds,
-		Entry: log.WithFields(log.Fields{
-			"ds": formatMeta(ds.ObjectMeta),
+		DSConfig: config,
+		FieldLogger: log.WithFields(log.Fields{
+			"daemonset": formatMeta(config.ObjectMeta),
 		}),
 	}, nil
 }
 
 // DSConfig is a DaemonSet control configuration
 type DSConfig struct {
-	// Reader with daemon set to update, will be used if present
-	Reader io.Reader
-	// DaemonSet is already parsed daemon set, will be used if present
-	DaemonSet *appsv1.DaemonSet
+	// DaemonSet specifies the existing resource
+	appsv1.DaemonSet
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
-func (c *DSConfig) CheckAndSetDefaults() error {
-	if c.Reader == nil && c.DaemonSet == nil {
-		return trace.BadParameter("missing parameter Reader or DaemonSet")
-	}
+func (c *DSConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
+	updateTypeMetaDaemonset(&c.DaemonSet)
 	return nil
 }
 
@@ -78,8 +61,7 @@ func (c *DSConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type DSControl struct {
 	DSConfig
-	daemonSet appsv1.DaemonSet
-	*log.Entry
+	log.FieldLogger
 }
 
 // collectPods returns pods created by this daemon set
@@ -88,28 +70,28 @@ func (c *DSControl) collectPods(daemonSet *v1beta1.DaemonSet) (map[string]v1.Pod
 	if daemonSet.Spec.Selector != nil {
 		labels = daemonSet.Spec.Selector.MatchLabels
 	}
-	pods, err := CollectPods(daemonSet.Namespace, labels, c.Entry, c.Client, func(ref metav1.OwnerReference) bool {
+	pods, err := CollectPods(daemonSet.Namespace, labels, c.FieldLogger, c.Client, func(ref metav1.OwnerReference) bool {
 		return ref.Kind == KindDaemonSet && ref.UID == daemonSet.UID
 	})
 	return pods, trace.Wrap(err)
 }
 
 func (c *DSControl) Delete(ctx context.Context, cascade bool) error {
-	c.Infof("delete %v", formatMeta(c.daemonSet.ObjectMeta))
+	c.Infof("delete %v", formatMeta(c.DaemonSet.ObjectMeta))
 
-	daemons := c.Client.Extensions().DaemonSets(c.daemonSet.Namespace)
-	currentDS, err := daemons.Get(c.daemonSet.Name, metav1.GetOptions{})
+	daemons := c.Client.ExtensionsV1beta1().DaemonSets(c.DaemonSet.Namespace)
+	currentDS, err := daemons.Get(c.DaemonSet.Name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
-	pods := c.Client.Core().Pods(c.daemonSet.Namespace)
+	pods := c.Client.Core().Pods(c.DaemonSet.Namespace)
 	currentPods, err := c.collectPods(currentDS)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	c.Info("deleting current daemon set")
 	deletePolicy := metav1.DeletePropagationForeground
-	err = daemons.Delete(c.daemonSet.Name, &metav1.DeleteOptions{
+	err = daemons.Delete(c.DaemonSet.Name, &metav1.DeleteOptions{
 		PropagationPolicy: &deletePolicy,
 	})
 	if err != nil {
@@ -117,7 +99,7 @@ func (c *DSControl) Delete(ctx context.Context, cascade bool) error {
 	}
 
 	err = waitForObjectDeletion(func() error {
-		_, err := daemons.Get(c.daemonSet.Name, metav1.GetOptions{})
+		_, err := daemons.Get(c.DaemonSet.Name, metav1.GetOptions{})
 		return ConvertError(err)
 	})
 	if err != nil {
@@ -127,15 +109,15 @@ func (c *DSControl) Delete(ctx context.Context, cascade bool) error {
 	if !cascade {
 		c.Info("cascade not set, returning")
 	}
-	err = deletePods(pods, currentPods, *c.Entry)
+	err = deletePods(pods, currentPods, c.FieldLogger)
 	return trace.Wrap(err)
 }
 
 func (c *DSControl) Upsert(ctx context.Context) error {
-	c.Infof("upsert %v", formatMeta(c.daemonSet.ObjectMeta))
+	c.Infof("upsert %v", formatMeta(c.DaemonSet.ObjectMeta))
 
-	daemons := c.Client.Apps().DaemonSets(c.daemonSet.Namespace)
-	currentDS, err := daemons.Get(c.daemonSet.Name, metav1.GetOptions{})
+	daemons := c.Client.Apps().DaemonSets(c.DaemonSet.Namespace)
+	currentDS, err := daemons.Get(c.DaemonSet.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -146,7 +128,7 @@ func (c *DSControl) Upsert(ctx context.Context) error {
 	}
 
 	if currentDS != nil {
-		control, err := NewDSControl(DSConfig{DaemonSet: currentDS, Client: c.Client})
+		control, err := NewDSControl(DSConfig{DaemonSet: *currentDS, Client: c.Client})
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -157,12 +139,12 @@ func (c *DSControl) Upsert(ctx context.Context) error {
 	}
 
 	c.Info("creating new daemon set")
-	c.daemonSet.UID = ""
-	c.daemonSet.SelfLink = ""
-	c.daemonSet.ResourceVersion = ""
+	c.DaemonSet.UID = ""
+	c.DaemonSet.SelfLink = ""
+	c.DaemonSet.ResourceVersion = ""
 
 	err = withExponentialBackoff(func() error {
-		_, err = daemons.Create(&c.daemonSet)
+		_, err = daemons.Create(&c.DaemonSet)
 		return ConvertError(err)
 	})
 	return trace.Wrap(err)
@@ -170,15 +152,15 @@ func (c *DSControl) Upsert(ctx context.Context) error {
 
 func (c *DSControl) nodeSelector() labels.Selector {
 	set := make(labels.Set)
-	for key, val := range c.daemonSet.Spec.Template.Spec.NodeSelector {
+	for key, val := range c.DaemonSet.Spec.Template.Spec.NodeSelector {
 		set[key] = val
 	}
 	return set.AsSelector()
 }
 
 func (c *DSControl) Status() error {
-	daemons := c.Client.Extensions().DaemonSets(c.daemonSet.Namespace)
-	currentDS, err := daemons.Get(c.daemonSet.Name, metav1.GetOptions{})
+	daemons := c.Client.ExtensionsV1beta1().DaemonSets(c.DaemonSet.Namespace)
+	currentDS, err := daemons.Get(c.DaemonSet.Name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
@@ -201,5 +183,12 @@ func (c *DSControl) Status() error {
 		return nil
 	}
 
-	return checkRunning(currentPods, nodes.Items, c.Entry)
+	return checkRunning(currentPods, nodes.Items, c.FieldLogger)
+}
+
+func updateTypeMetaDaemonset(r *appsv1.DaemonSet) {
+	r.Kind = KindDaemonSet
+	if r.APIVersion == "" {
+		r.APIVersion = v1beta1.SchemeGroupVersion.String()
+	}
 }

--- a/ds.go
+++ b/ds.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// NewDSControl returns new instance of DaemonSet updater
-func NewDSControl(config DSConfig) (*DSControl, error) {
+// NewDaemonSetControl returns new instance of DaemonSet controller
+func NewDaemonSetControl(config DSConfig) (*DSControl, error) {
 	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -131,7 +131,7 @@ func (c *DSControl) Upsert(ctx context.Context) error {
 	}
 
 	if currentDS != nil {
-		control, err := NewDSControl(DSConfig{DaemonSet: currentDS, Client: c.Client})
+		control, err := NewDaemonSetControl(DSConfig{DaemonSet: currentDS, Client: c.Client})
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/policies.go
+++ b/policies.go
@@ -17,8 +17,8 @@ package rigging
 import (
 	"context"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -32,17 +32,16 @@ func NewPodSecurityPolicyControl(config PodSecurityPolicyConfig) (*PodSecurityPo
 	}
 	return &PodSecurityPolicyControl{
 		PodSecurityPolicyConfig: config,
-		PodSecurityPolicy:       config.Policy,
-		Entry: log.WithFields(log.Fields{
-			"pod_security_policy": formatMeta(config.Policy.ObjectMeta),
+		FieldLogger: log.WithFields(log.Fields{
+			"podsecuritypolicy": formatMeta(config.ObjectMeta),
 		}),
 	}, nil
 }
 
 // PodSecurityPolicyConfig defines controller configuration
 type PodSecurityPolicyConfig struct {
-	// Policy is the existing pod security policy
-	Policy v1beta1.PodSecurityPolicy
+	// PodSecurityPolicy is the existing pod security policy
+	v1beta1.PodSecurityPolicy
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
@@ -51,8 +50,7 @@ func (c *PodSecurityPolicyConfig) CheckAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	c.Policy.Kind = KindPodSecurityPolicy
-	c.Policy.APIVersion = ExtensionsAPIVersion
+	updateTypeMetaPodSecurityPolicy(&c.PodSecurityPolicy)
 	return nil
 }
 
@@ -60,8 +58,7 @@ func (c *PodSecurityPolicyConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type PodSecurityPolicyControl struct {
 	PodSecurityPolicyConfig
-	v1beta1.PodSecurityPolicy
-	*log.Entry
+	log.FieldLogger
 }
 
 func (c *PodSecurityPolicyControl) Delete(ctx context.Context, cascade bool) error {
@@ -84,10 +81,10 @@ func (c *PodSecurityPolicyControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = policies.Create(&c.Policy)
+		_, err = policies.Create(&c.PodSecurityPolicy)
 		return ConvertErrorWithContext(err, "cannot create pod security policy %q", formatMeta(c.ObjectMeta))
 	}
-	_, err = policies.Update(&c.Policy)
+	_, err = policies.Update(&c.PodSecurityPolicy)
 	return ConvertError(err)
 }
 
@@ -95,4 +92,11 @@ func (c *PodSecurityPolicyControl) Status() error {
 	policies := c.Client.ExtensionsV1beta1().PodSecurityPolicies()
 	_, err := policies.Get(c.Name, metav1.GetOptions{})
 	return ConvertError(err)
+}
+
+func updateTypeMetaPodSecurityPolicy(r *v1beta1.PodSecurityPolicy) {
+	r.Kind = KindPodSecurityPolicy
+	if r.APIVersion == "" {
+		r.APIVersion = v1beta1.SchemeGroupVersion.String()
+	}
 }

--- a/policies.go
+++ b/policies.go
@@ -41,16 +41,19 @@ func NewPodSecurityPolicyControl(config PodSecurityPolicyConfig) (*PodSecurityPo
 // PodSecurityPolicyConfig defines controller configuration
 type PodSecurityPolicyConfig struct {
 	// PodSecurityPolicy is the existing pod security policy
-	v1beta1.PodSecurityPolicy
+	*v1beta1.PodSecurityPolicy
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
 func (c *PodSecurityPolicyConfig) CheckAndSetDefaults() error {
+	if c.PodSecurityPolicy == nil {
+		return trace.BadParameter("missing parameter PodSecurityPolicy")
+	}
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	updateTypeMetaPodSecurityPolicy(&c.PodSecurityPolicy)
+	updateTypeMetaPodSecurityPolicy(c.PodSecurityPolicy)
 	return nil
 }
 
@@ -81,10 +84,10 @@ func (c *PodSecurityPolicyControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = policies.Create(&c.PodSecurityPolicy)
+		_, err = policies.Create(c.PodSecurityPolicy)
 		return ConvertErrorWithContext(err, "cannot create pod security policy %q", formatMeta(c.ObjectMeta))
 	}
-	_, err = policies.Update(&c.PodSecurityPolicy)
+	_, err = policies.Update(c.PodSecurityPolicy)
 	return ConvertError(err)
 }
 

--- a/rcc.go
+++ b/rcc.go
@@ -17,11 +17,10 @@ package rigging
 import (
 	"context"
 	"fmt"
-	"io"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
-	"k8s.io/api/core/v1"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -29,46 +28,32 @@ import (
 
 // NewRCControl returns new instance of ReplicationController updater
 func NewRCControl(config RCConfig) (*RCControl, error) {
-	err := config.CheckAndSetDefaults()
+	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var rc *v1.ReplicationController
-	if config.ReplicationController != nil {
-		rc = config.ReplicationController
-	} else {
-		rc, err = ParseReplicationController(config.Reader)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-	rc.Kind = KindReplicationController
 	return &RCControl{
-		RCConfig:              config,
-		replicationController: *rc,
-		Entry: log.WithFields(log.Fields{
-			"rc": fmt.Sprintf("%v/%v", Namespace(rc.Namespace), rc.Name),
+		RCConfig: config,
+		FieldLogger: log.WithFields(log.Fields{
+			"replicationcontroller": fmt.Sprintf("%v/%v",
+				Namespace(config.Namespace), config.Name),
 		}),
 	}, nil
 }
 
 // RCConfig is a ReplicationController control configuration
 type RCConfig struct {
-	// Reader with daemon set to update, will be used if present
-	Reader io.Reader
 	// ReplicationController is already parsed daemon set, will be used if present
-	ReplicationController *v1.ReplicationController
+	v1.ReplicationController
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
-func (c *RCConfig) CheckAndSetDefaults() error {
-	if c.Reader == nil && c.ReplicationController == nil {
-		return trace.BadParameter("missing parameter Reader or ReplicationController")
-	}
+func (c *RCConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
+	updateTypeMetaReplicationController(&c.ReplicationController)
 	return nil
 }
 
@@ -76,17 +61,16 @@ func (c *RCConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type RCControl struct {
 	RCConfig
-	replicationController v1.ReplicationController
-	*log.Entry
+	log.FieldLogger
 }
 
 // collectPods returns pods created by this RC
 func (c *RCControl) collectPods(replicationController *v1.ReplicationController) ([]v1.Pod, error) {
 	set := make(labels.Set)
-	for key, val := range c.replicationController.Spec.Selector {
+	for key, val := range c.ReplicationController.Spec.Selector {
 		set[key] = val
 	}
-	pods, err := CollectPods(replicationController.Namespace, set, c.Entry, c.Client, func(ref metav1.OwnerReference) bool {
+	pods, err := CollectPods(replicationController.Namespace, set, c.FieldLogger, c.Client, func(ref metav1.OwnerReference) bool {
 		return ref.Kind == KindReplicationController && ref.UID == replicationController.UID
 	})
 	var podList []v1.Pod
@@ -97,21 +81,21 @@ func (c *RCControl) collectPods(replicationController *v1.ReplicationController)
 }
 
 func (c *RCControl) Delete(ctx context.Context, cascade bool) error {
-	c.Infof("delete %v", formatMeta(c.replicationController.ObjectMeta))
+	c.Infof("delete %v", formatMeta(c.ReplicationController.ObjectMeta))
 
-	rcs := c.Client.Core().ReplicationControllers(c.replicationController.Namespace)
-	currentRC, err := rcs.Get(c.replicationController.Name, metav1.GetOptions{})
+	rcs := c.Client.Core().ReplicationControllers(c.ReplicationController.Namespace)
+	currentRC, err := rcs.Get(c.ReplicationController.Name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
-	pods := c.Client.Core().Pods(c.replicationController.Namespace)
+	pods := c.Client.Core().Pods(c.ReplicationController.Namespace)
 	currentPods, err := c.collectPods(currentRC)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	c.Info("deleting current replication controller")
 	deletePolicy := metav1.DeletePropagationForeground
-	err = rcs.Delete(c.replicationController.Name, &metav1.DeleteOptions{
+	err = rcs.Delete(c.ReplicationController.Name, &metav1.DeleteOptions{
 		PropagationPolicy: &deletePolicy,
 	})
 	if err != nil {
@@ -119,7 +103,7 @@ func (c *RCControl) Delete(ctx context.Context, cascade bool) error {
 	}
 
 	err = waitForObjectDeletion(func() error {
-		_, err := rcs.Get(c.replicationController.Name, metav1.GetOptions{})
+		_, err := rcs.Get(c.ReplicationController.Name, metav1.GetOptions{})
 		return ConvertError(err)
 	})
 	if err != nil {
@@ -129,15 +113,15 @@ func (c *RCControl) Delete(ctx context.Context, cascade bool) error {
 	if !cascade {
 		c.Info("cascade not set, returning")
 	}
-	err = deletePodsList(pods, currentPods, *c.Entry)
+	err = deletePodsList(pods, currentPods, c.FieldLogger)
 	return trace.Wrap(err)
 }
 
 func (c *RCControl) Upsert(ctx context.Context) error {
-	c.Infof("upsert %v", formatMeta(c.replicationController.ObjectMeta))
+	c.Infof("upsert %v", formatMeta(c.ReplicationController.ObjectMeta))
 
-	rcs := c.Client.Core().ReplicationControllers(c.replicationController.Namespace)
-	currentRC, err := rcs.Get(c.replicationController.Name, metav1.GetOptions{})
+	rcs := c.Client.Core().ReplicationControllers(c.ReplicationController.Namespace)
+	currentRC, err := rcs.Get(c.ReplicationController.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -147,7 +131,7 @@ func (c *RCControl) Upsert(ctx context.Context) error {
 	}
 
 	if currentRC != nil {
-		control, err := NewRCControl(RCConfig{ReplicationController: currentRC, Client: c.Client})
+		control, err := NewRCControl(RCConfig{ReplicationController: *currentRC, Client: c.Client})
 		if err != nil {
 			return ConvertError(err)
 		}
@@ -157,12 +141,12 @@ func (c *RCControl) Upsert(ctx context.Context) error {
 		}
 	}
 
-	c.replicationController.UID = ""
-	c.replicationController.SelfLink = ""
-	c.replicationController.ResourceVersion = ""
+	c.ReplicationController.UID = ""
+	c.ReplicationController.SelfLink = ""
+	c.ReplicationController.ResourceVersion = ""
 
 	err = withExponentialBackoff(func() error {
-		_, err = rcs.Create(&c.replicationController)
+		_, err = rcs.Create(&c.ReplicationController)
 		return ConvertError(err)
 	})
 	return trace.Wrap(err)
@@ -170,15 +154,15 @@ func (c *RCControl) Upsert(ctx context.Context) error {
 
 func (c *RCControl) nodeSelector() labels.Selector {
 	set := make(labels.Set)
-	for key, val := range c.replicationController.Spec.Template.Spec.NodeSelector {
+	for key, val := range c.ReplicationController.Spec.Template.Spec.NodeSelector {
 		set[key] = val
 	}
 	return set.AsSelector()
 }
 
 func (c *RCControl) Status() error {
-	rcs := c.Client.Core().ReplicationControllers(c.replicationController.Namespace)
-	currentRC, err := rcs.Get(c.replicationController.Name, metav1.GetOptions{})
+	rcs := c.Client.Core().ReplicationControllers(c.ReplicationController.Namespace)
+	currentRC, err := rcs.Get(c.ReplicationController.Name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
@@ -199,4 +183,11 @@ func (c *RCControl) Status() error {
 		}
 	}
 	return nil
+}
+
+func updateTypeMetaReplicationController(r *v1.ReplicationController) {
+	r.Kind = KindReplicationController
+	if r.APIVersion == "" {
+		r.APIVersion = v1.SchemeGroupVersion.String()
+	}
 }

--- a/rcc.go
+++ b/rcc.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// NewRCControl returns new instance of ReplicationController updater
-func NewRCControl(config RCConfig) (*RCControl, error) {
+// NewReplicationControllerControl returns new instance of ReplicationController control
+func NewReplicationControllerControl(config RCConfig) (*RCControl, error) {
 	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -43,7 +43,7 @@ func NewRCControl(config RCConfig) (*RCControl, error) {
 
 // RCConfig is a ReplicationController control configuration
 type RCConfig struct {
-	// ReplicationController is already parsed daemon set, will be used if present
+	// ReplicationController specifies the existing ReplicationController
 	*v1.ReplicationController
 	// Client is k8s client
 	Client *kubernetes.Clientset
@@ -131,7 +131,7 @@ func (c *RCControl) Upsert(ctx context.Context) error {
 	}
 
 	if currentRC != nil {
-		control, err := NewRCControl(RCConfig{ReplicationController: currentRC, Client: c.Client})
+		control, err := NewReplicationControllerControl(RCConfig{ReplicationController: currentRC, Client: c.Client})
 		if err != nil {
 			return ConvertError(err)
 		}

--- a/rcc.go
+++ b/rcc.go
@@ -44,7 +44,7 @@ func NewRCControl(config RCConfig) (*RCControl, error) {
 // RCConfig is a ReplicationController control configuration
 type RCConfig struct {
 	// ReplicationController is already parsed daemon set, will be used if present
-	v1.ReplicationController
+	*v1.ReplicationController
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
@@ -53,7 +53,7 @@ func (c *RCConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	updateTypeMetaReplicationController(&c.ReplicationController)
+	updateTypeMetaReplicationController(c.ReplicationController)
 	return nil
 }
 
@@ -131,7 +131,7 @@ func (c *RCControl) Upsert(ctx context.Context) error {
 	}
 
 	if currentRC != nil {
-		control, err := NewRCControl(RCConfig{ReplicationController: *currentRC, Client: c.Client})
+		control, err := NewRCControl(RCConfig{ReplicationController: currentRC, Client: c.Client})
 		if err != nil {
 			return ConvertError(err)
 		}
@@ -146,7 +146,7 @@ func (c *RCControl) Upsert(ctx context.Context) error {
 	c.ReplicationController.ResourceVersion = ""
 
 	err = withExponentialBackoff(func() error {
-		_, err = rcs.Create(&c.ReplicationController)
+		_, err = rcs.Create(c.ReplicationController)
 		return ConvertError(err)
 	})
 	return trace.Wrap(err)

--- a/roles.go
+++ b/roles.go
@@ -41,16 +41,19 @@ func NewRoleControl(config RoleConfig) (*RoleControl, error) {
 // RoleConfig defines controller configuration
 type RoleConfig struct {
 	// Role is the existing role
-	v1.Role
+	*v1.Role
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
 func (c *RoleConfig) checkAndSetDefaults() error {
+	if c.Role == nil {
+		return trace.BadParameter("missing parameter Role")
+	}
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	updateTypeMetaRole(&c.Role)
+	updateTypeMetaRole(c.Role)
 	return nil
 }
 
@@ -81,10 +84,10 @@ func (c *RoleControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = roles.Create(&c.Role)
+		_, err = roles.Create(c.Role)
 		return ConvertErrorWithContext(err, "cannot create role %q", formatMeta(c.ObjectMeta))
 	}
-	_, err = roles.Update(&c.Role)
+	_, err = roles.Update(c.Role)
 	return ConvertError(err)
 }
 
@@ -111,16 +114,19 @@ func NewClusterRoleControl(config ClusterRoleConfig) (*ClusterRoleControl, error
 // ClusterRoleConfig defines controller configuration
 type ClusterRoleConfig struct {
 	// Role is the existing cluster role
-	v1.ClusterRole
+	*v1.ClusterRole
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
 func (c *ClusterRoleConfig) checkAndSetDefaults() error {
+	if c.ClusterRole == nil {
+		return trace.BadParameter("missing parameter ClusterRole")
+	}
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	updateTypeMetaClusterRole(&c.ClusterRole)
+	updateTypeMetaClusterRole(c.ClusterRole)
 	return nil
 }
 
@@ -151,10 +157,10 @@ func (c *ClusterRoleControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = roles.Create(&c.ClusterRole)
+		_, err = roles.Create(c.ClusterRole)
 		return ConvertErrorWithContext(err, "cannot create cluster role %q", formatMeta(c.ObjectMeta))
 	}
-	_, err = roles.Update(&c.ClusterRole)
+	_, err = roles.Update(c.ClusterRole)
 	return ConvertError(err)
 }
 
@@ -181,16 +187,19 @@ func NewRoleBindingControl(config RoleBindingConfig) (*RoleBindingControl, error
 // RoleBindingConfig defines controller configuration
 type RoleBindingConfig struct {
 	// RoleBinding is the existing role binding
-	v1.RoleBinding
+	*v1.RoleBinding
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
 func (c *RoleBindingConfig) checkAndSetDefaults() error {
+	if c.RoleBinding == nil {
+		return trace.BadParameter("missing parameter RoleBinding")
+	}
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	updateTypeMetaRoleBinding(&c.RoleBinding)
+	updateTypeMetaRoleBinding(c.RoleBinding)
 	return nil
 }
 
@@ -221,10 +230,10 @@ func (c *RoleBindingControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = bindings.Create(&c.RoleBinding)
+		_, err = bindings.Create(c.RoleBinding)
 		return ConvertErrorWithContext(err, "cannot create role binding %q", formatMeta(c.ObjectMeta))
 	}
-	_, err = bindings.Update(&c.RoleBinding)
+	_, err = bindings.Update(c.RoleBinding)
 	return ConvertError(err)
 }
 
@@ -251,16 +260,19 @@ func NewClusterRoleBindingControl(config ClusterRoleBindingConfig) (*ClusterRole
 // ClusterRoleBindingConfig defines controller configuration
 type ClusterRoleBindingConfig struct {
 	// Binding is the existing cluster role binding
-	v1.ClusterRoleBinding
+	*v1.ClusterRoleBinding
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
 func (c *ClusterRoleBindingConfig) checkAndSetDefaults() error {
+	if c.ClusterRoleBinding == nil {
+		return trace.BadParameter("missing parameter ClusterRoleBinding")
+	}
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	updateTypeMetaClusterRoleBinding(&c.ClusterRoleBinding)
+	updateTypeMetaClusterRoleBinding(c.ClusterRoleBinding)
 	return nil
 }
 
@@ -291,10 +303,10 @@ func (c *ClusterRoleBindingControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = bindings.Create(&c.ClusterRoleBinding)
+		_, err = bindings.Create(c.ClusterRoleBinding)
 		return ConvertErrorWithContext(err, "cannot create cluster role binding %q", formatMeta(c.ObjectMeta))
 	}
-	_, err = bindings.Update(&c.ClusterRoleBinding)
+	_, err = bindings.Update(c.ClusterRoleBinding)
 	return ConvertError(err)
 }
 

--- a/roles.go
+++ b/roles.go
@@ -17,8 +17,8 @@ package rigging
 import (
 	"context"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -26,14 +26,13 @@ import (
 
 // NewRoleControl returns a new instance of the Role controller
 func NewRoleControl(config RoleConfig) (*RoleControl, error) {
-	err := config.CheckAndSetDefaults()
+	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &RoleControl{
 		RoleConfig: config,
-		Role:       config.Role,
-		Entry: log.WithFields(log.Fields{
+		FieldLogger: log.WithFields(log.Fields{
 			"role": formatMeta(config.Role.ObjectMeta),
 		}),
 	}, nil
@@ -42,17 +41,16 @@ func NewRoleControl(config RoleConfig) (*RoleControl, error) {
 // RoleConfig defines controller configuration
 type RoleConfig struct {
 	// Role is the existing role
-	Role v1.Role
+	v1.Role
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
-func (c *RoleConfig) CheckAndSetDefaults() error {
+func (c *RoleConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	c.Role.Kind = KindRole
-	c.Role.APIVersion = RBACAPIVersion
+	updateTypeMetaRole(&c.Role)
 	return nil
 }
 
@@ -60,8 +58,7 @@ func (c *RoleConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type RoleControl struct {
 	RoleConfig
-	v1.Role
-	*log.Entry
+	log.FieldLogger
 }
 
 func (c *RoleControl) Delete(ctx context.Context, cascade bool) error {
@@ -99,15 +96,14 @@ func (c *RoleControl) Status() error {
 
 // NewClusterRoleControl returns a new instance of the ClusterRole controller
 func NewClusterRoleControl(config ClusterRoleConfig) (*ClusterRoleControl, error) {
-	err := config.CheckAndSetDefaults()
+	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &ClusterRoleControl{
 		ClusterRoleConfig: config,
-		ClusterRole:       config.Role,
-		Entry: log.WithFields(log.Fields{
-			"cluster_role": formatMeta(config.Role.ObjectMeta),
+		FieldLogger: log.WithFields(log.Fields{
+			"cluster_role": formatMeta(config.ObjectMeta),
 		}),
 	}, nil
 }
@@ -115,17 +111,16 @@ func NewClusterRoleControl(config ClusterRoleConfig) (*ClusterRoleControl, error
 // ClusterRoleConfig defines controller configuration
 type ClusterRoleConfig struct {
 	// Role is the existing cluster role
-	Role v1.ClusterRole
+	v1.ClusterRole
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
-func (c *ClusterRoleConfig) CheckAndSetDefaults() error {
+func (c *ClusterRoleConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	c.Role.Kind = KindClusterRole
-	c.Role.APIVersion = RBACAPIVersion
+	updateTypeMetaClusterRole(&c.ClusterRole)
 	return nil
 }
 
@@ -133,8 +128,7 @@ func (c *ClusterRoleConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type ClusterRoleControl struct {
 	ClusterRoleConfig
-	v1.ClusterRole
-	*log.Entry
+	log.FieldLogger
 }
 
 func (c *ClusterRoleControl) Delete(ctx context.Context, cascade bool) error {
@@ -157,10 +151,10 @@ func (c *ClusterRoleControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = roles.Create(&c.Role)
+		_, err = roles.Create(&c.ClusterRole)
 		return ConvertErrorWithContext(err, "cannot create cluster role %q", formatMeta(c.ObjectMeta))
 	}
-	_, err = roles.Update(&c.Role)
+	_, err = roles.Update(&c.ClusterRole)
 	return ConvertError(err)
 }
 
@@ -172,15 +166,14 @@ func (c *ClusterRoleControl) Status() error {
 
 // NewRoleBindingControl returns a new instance of the RoleBinding controller
 func NewRoleBindingControl(config RoleBindingConfig) (*RoleBindingControl, error) {
-	err := config.CheckAndSetDefaults()
+	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &RoleBindingControl{
 		RoleBindingConfig: config,
-		RoleBinding:       config.Binding,
-		Entry: log.WithFields(log.Fields{
-			"role_binding": formatMeta(config.Binding.ObjectMeta),
+		FieldLogger: log.WithFields(log.Fields{
+			"role_binding": formatMeta(config.ObjectMeta),
 		}),
 	}, nil
 }
@@ -188,17 +181,16 @@ func NewRoleBindingControl(config RoleBindingConfig) (*RoleBindingControl, error
 // RoleBindingConfig defines controller configuration
 type RoleBindingConfig struct {
 	// RoleBinding is the existing role binding
-	Binding v1.RoleBinding
+	v1.RoleBinding
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
-func (c *RoleBindingConfig) CheckAndSetDefaults() error {
+func (c *RoleBindingConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	c.Binding.Kind = KindRoleBinding
-	c.Binding.APIVersion = RBACAPIVersion
+	updateTypeMetaRoleBinding(&c.RoleBinding)
 	return nil
 }
 
@@ -206,8 +198,7 @@ func (c *RoleBindingConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type RoleBindingControl struct {
 	RoleBindingConfig
-	v1.RoleBinding
-	*log.Entry
+	log.FieldLogger
 }
 
 func (c *RoleBindingControl) Delete(ctx context.Context, cascade bool) error {
@@ -245,15 +236,14 @@ func (c *RoleBindingControl) Status() error {
 
 // NewClusterRoleBindingControl returns a new instance of the ClusterRoleBinding controller
 func NewClusterRoleBindingControl(config ClusterRoleBindingConfig) (*ClusterRoleBindingControl, error) {
-	err := config.CheckAndSetDefaults()
+	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &ClusterRoleBindingControl{
 		ClusterRoleBindingConfig: config,
-		ClusterRoleBinding:       config.Binding,
-		Entry: log.WithFields(log.Fields{
-			"cluster_role_binding": formatMeta(config.Binding.ObjectMeta),
+		FieldLogger: log.WithFields(log.Fields{
+			"cluster_role_binding": formatMeta(config.ObjectMeta),
 		}),
 	}, nil
 }
@@ -261,17 +251,16 @@ func NewClusterRoleBindingControl(config ClusterRoleBindingConfig) (*ClusterRole
 // ClusterRoleBindingConfig defines controller configuration
 type ClusterRoleBindingConfig struct {
 	// Binding is the existing cluster role binding
-	Binding v1.ClusterRoleBinding
+	v1.ClusterRoleBinding
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
-func (c *ClusterRoleBindingConfig) CheckAndSetDefaults() error {
+func (c *ClusterRoleBindingConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	c.Binding.Kind = KindClusterRoleBinding
-	c.Binding.APIVersion = RBACAPIVersion
+	updateTypeMetaClusterRoleBinding(&c.ClusterRoleBinding)
 	return nil
 }
 
@@ -279,8 +268,7 @@ func (c *ClusterRoleBindingConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type ClusterRoleBindingControl struct {
 	ClusterRoleBindingConfig
-	v1.ClusterRoleBinding
-	*log.Entry
+	log.FieldLogger
 }
 
 func (c *ClusterRoleBindingControl) Delete(ctx context.Context, cascade bool) error {
@@ -314,4 +302,32 @@ func (c *ClusterRoleBindingControl) Status() error {
 	bindings := c.Client.RbacV1().ClusterRoleBindings()
 	_, err := bindings.Get(c.Name, metav1.GetOptions{})
 	return ConvertError(err)
+}
+
+func updateTypeMetaRole(r *v1.Role) {
+	r.Kind = KindRole
+	if r.APIVersion == "" {
+		r.APIVersion = v1.SchemeGroupVersion.String()
+	}
+}
+
+func updateTypeMetaRoleBinding(r *v1.RoleBinding) {
+	r.Kind = KindRoleBinding
+	if r.APIVersion == "" {
+		r.APIVersion = v1.SchemeGroupVersion.String()
+	}
+}
+
+func updateTypeMetaClusterRole(r *v1.ClusterRole) {
+	r.Kind = KindClusterRole
+	if r.APIVersion == "" {
+		r.APIVersion = v1.SchemeGroupVersion.String()
+	}
+}
+
+func updateTypeMetaClusterRoleBinding(r *v1.ClusterRoleBinding) {
+	r.Kind = KindClusterRoleBinding
+	if r.APIVersion == "" {
+		r.APIVersion = v1.SchemeGroupVersion.String()
+	}
 }

--- a/secret.go
+++ b/secret.go
@@ -40,7 +40,7 @@ func NewSecretControl(config SecretConfig) (*SecretControl, error) {
 
 // SecretConfig  is a Secret control configuration
 type SecretConfig struct {
-	// Secret is already parsed daemon set, will be used if present
+	// Secret specifies the existing secret
 	*v1.Secret
 	// Client is k8s client
 	Client *kubernetes.Clientset

--- a/secret.go
+++ b/secret.go
@@ -41,16 +41,19 @@ func NewSecretControl(config SecretConfig) (*SecretControl, error) {
 // SecretConfig  is a Secret control configuration
 type SecretConfig struct {
 	// Secret is already parsed daemon set, will be used if present
-	v1.Secret
+	*v1.Secret
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
 func (c *SecretConfig) checkAndSetDefaults() error {
+	if c.Secret == nil {
+		return trace.BadParameter("missing parameter Secret")
+	}
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	updateTypeMetaSecret(&c.Secret)
+	updateTypeMetaSecret(c.Secret)
 	return nil
 }
 
@@ -81,10 +84,10 @@ func (c *SecretControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = secrets.Create(&c.Secret)
+		_, err = secrets.Create(c.Secret)
 		return ConvertError(err)
 	}
-	_, err = secrets.Update(&c.Secret)
+	_, err = secrets.Update(c.Secret)
 	return ConvertError(err)
 }
 

--- a/secret.go
+++ b/secret.go
@@ -16,57 +16,41 @@ package rigging
 
 import (
 	"context"
-	"io"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
-	"k8s.io/api/core/v1"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 // NewSecretControl returns new instance of Secret updater
 func NewSecretControl(config SecretConfig) (*SecretControl, error) {
-	err := config.CheckAndSetDefaults()
+	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var rc *v1.Secret
-	if config.Secret != nil {
-		rc = config.Secret
-	} else {
-		rc, err = ParseSecret(config.Reader)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-	rc.Kind = KindSecret
 	return &SecretControl{
 		SecretConfig: config,
-		secret:       *rc,
-		Entry: log.WithFields(log.Fields{
-			"secret": formatMeta(rc.ObjectMeta),
+		FieldLogger: log.WithFields(log.Fields{
+			"secret": formatMeta(config.Secret.ObjectMeta),
 		}),
 	}, nil
 }
 
 // SecretConfig  is a Secret control configuration
 type SecretConfig struct {
-	// Reader with daemon set to update, will be used if present
-	Reader io.Reader
 	// Secret is already parsed daemon set, will be used if present
-	Secret *v1.Secret
+	v1.Secret
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
-func (c *SecretConfig) CheckAndSetDefaults() error {
-	if c.Reader == nil && c.Secret == nil {
-		return trace.BadParameter("missing parameter Reader or Secret")
-	}
+func (c *SecretConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
+	updateTypeMetaSecret(&c.Secret)
 	return nil
 }
 
@@ -74,39 +58,45 @@ func (c *SecretConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type SecretControl struct {
 	SecretConfig
-	secret v1.Secret
-	*log.Entry
+	log.FieldLogger
 }
 
 func (c *SecretControl) Delete(ctx context.Context, cascade bool) error {
-	c.Infof("delete %v", formatMeta(c.secret.ObjectMeta))
+	c.Infof("delete %v", formatMeta(c.Secret.ObjectMeta))
 
-	err := c.Client.Core().Secrets(c.secret.Namespace).Delete(c.secret.Name, nil)
+	err := c.Client.Core().Secrets(c.Secret.Namespace).Delete(c.Secret.Name, nil)
 	return ConvertError(err)
 }
 
 func (c *SecretControl) Upsert(ctx context.Context) error {
-	c.Infof("upsert %v", formatMeta(c.secret.ObjectMeta))
+	c.Infof("upsert %v", formatMeta(c.Secret.ObjectMeta))
 
-	secrets := c.Client.Core().Secrets(c.secret.Namespace)
-	c.secret.UID = ""
-	c.secret.SelfLink = ""
-	c.secret.ResourceVersion = ""
-	_, err := secrets.Get(c.secret.Name, metav1.GetOptions{})
+	secrets := c.Client.Core().Secrets(c.Secret.Namespace)
+	c.Secret.UID = ""
+	c.Secret.SelfLink = ""
+	c.Secret.ResourceVersion = ""
+	_, err := secrets.Get(c.Secret.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = secrets.Create(&c.secret)
+		_, err = secrets.Create(&c.Secret)
 		return ConvertError(err)
 	}
-	_, err = secrets.Update(&c.secret)
+	_, err = secrets.Update(&c.Secret)
 	return ConvertError(err)
 }
 
 func (c *SecretControl) Status() error {
-	secrets := c.Client.Core().Secrets(c.secret.Namespace)
-	_, err := secrets.Get(c.secret.Name, metav1.GetOptions{})
+	secrets := c.Client.Core().Secrets(c.Secret.Namespace)
+	_, err := secrets.Get(c.Secret.Name, metav1.GetOptions{})
 	return ConvertError(err)
+}
+
+func updateTypeMetaSecret(r *v1.Secret) {
+	r.Kind = KindSecret
+	if r.APIVersion == "" {
+		r.APIVersion = v1.SchemeGroupVersion.String()
+	}
 }

--- a/service.go
+++ b/service.go
@@ -41,16 +41,19 @@ func NewServiceControl(config ServiceConfig) (*ServiceControl, error) {
 // ServiceConfig  is a Service control configuration
 type ServiceConfig struct {
 	// Service is already parsed daemon set, will be used if present
-	v1.Service
+	*v1.Service
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
 func (c *ServiceConfig) CheckAndSetDefaults() error {
+	if c.Service == nil {
+		return trace.BadParameter("missing parameter Service")
+	}
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	updateTypeMetaService(&c.Service)
+	updateTypeMetaService(c.Service)
 	return nil
 }
 
@@ -81,12 +84,12 @@ func (c *ServiceControl) Upsert(ctx context.Context) error {
 		c.Service.UID = ""
 		c.Service.SelfLink = ""
 		c.Service.ResourceVersion = ""
-		_, err = services.Create(&c.Service)
+		_, err = services.Create(c.Service)
 		return ConvertError(err)
 	}
 	c.Service.Spec.ClusterIP = currentService.Spec.ClusterIP
 	c.Service.ResourceVersion = currentService.ResourceVersion
-	_, err = services.Update(&c.Service)
+	_, err = services.Update(c.Service)
 	return ConvertError(err)
 }
 

--- a/service.go
+++ b/service.go
@@ -40,7 +40,7 @@ func NewServiceControl(config ServiceConfig) (*ServiceControl, error) {
 
 // ServiceConfig  is a Service control configuration
 type ServiceConfig struct {
-	// Service is already parsed daemon set, will be used if present
+	// Service specifies the existing service
 	*v1.Service
 	// Client is k8s client
 	Client *kubernetes.Clientset

--- a/service.go
+++ b/service.go
@@ -16,11 +16,10 @@ package rigging
 
 import (
 	"context"
-	"io"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
-	"k8s.io/api/core/v1"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -31,42 +30,27 @@ func NewServiceControl(config ServiceConfig) (*ServiceControl, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var rc *v1.Service
-	if config.Service != nil {
-		rc = config.Service
-	} else {
-		rc, err = ParseService(config.Reader)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-	rc.Kind = KindService
 	return &ServiceControl{
 		ServiceConfig: config,
-		service:       *rc,
-		Entry: log.WithFields(log.Fields{
-			"service": formatMeta(rc.ObjectMeta),
+		FieldLogger: log.WithFields(log.Fields{
+			"service": formatMeta(config.ObjectMeta),
 		}),
 	}, nil
 }
 
 // ServiceConfig  is a Service control configuration
 type ServiceConfig struct {
-	// Reader with daemon set to update, will be used if present
-	Reader io.Reader
 	// Service is already parsed daemon set, will be used if present
-	Service *v1.Service
+	v1.Service
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
 func (c *ServiceConfig) CheckAndSetDefaults() error {
-	if c.Reader == nil && c.Service == nil {
-		return trace.BadParameter("missing parameter Reader or Service")
-	}
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
+	updateTypeMetaService(&c.Service)
 	return nil
 }
 
@@ -74,41 +58,47 @@ func (c *ServiceConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type ServiceControl struct {
 	ServiceConfig
-	service v1.Service
-	*log.Entry
+	log.FieldLogger
 }
 
 func (c *ServiceControl) Delete(ctx context.Context, cascade bool) error {
-	c.Infof("delete %v", formatMeta(c.service.ObjectMeta))
+	c.Infof("delete %v", formatMeta(c.Service.ObjectMeta))
 
-	err := c.Client.Core().Services(c.service.Namespace).Delete(c.service.Name, nil)
+	err := c.Client.Core().Services(c.Service.Namespace).Delete(c.Service.Name, nil)
 	return ConvertError(err)
 }
 
 func (c *ServiceControl) Upsert(ctx context.Context) error {
-	c.Infof("upsert %v", formatMeta(c.service.ObjectMeta))
+	c.Infof("upsert %v", formatMeta(c.Service.ObjectMeta))
 
-	services := c.Client.Core().Services(c.service.Namespace)
-	currentService, err := services.Get(c.service.Name, metav1.GetOptions{})
+	services := c.Client.Core().Services(c.Service.Namespace)
+	currentService, err := services.Get(c.Service.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		c.service.UID = ""
-		c.service.SelfLink = ""
-		c.service.ResourceVersion = ""
-		_, err = services.Create(&c.service)
+		c.Service.UID = ""
+		c.Service.SelfLink = ""
+		c.Service.ResourceVersion = ""
+		_, err = services.Create(&c.Service)
 		return ConvertError(err)
 	}
-	c.service.Spec.ClusterIP = currentService.Spec.ClusterIP
-	c.service.ResourceVersion = currentService.ResourceVersion
-	_, err = services.Update(&c.service)
+	c.Service.Spec.ClusterIP = currentService.Spec.ClusterIP
+	c.Service.ResourceVersion = currentService.ResourceVersion
+	_, err = services.Update(&c.Service)
 	return ConvertError(err)
 }
 
 func (c *ServiceControl) Status() error {
-	services := c.Client.Core().Services(c.service.Namespace)
-	_, err := services.Get(c.service.Name, metav1.GetOptions{})
+	services := c.Client.Core().Services(c.Service.Namespace)
+	_, err := services.Get(c.Service.Name, metav1.GetOptions{})
 	return ConvertError(err)
+}
+
+func updateTypeMetaService(r *v1.Service) {
+	r.Kind = KindService
+	if r.APIVersion == "" {
+		r.APIVersion = v1.SchemeGroupVersion.String()
+	}
 }

--- a/serviceaccount.go
+++ b/serviceaccount.go
@@ -17,8 +17,8 @@ package rigging
 import (
 	"context"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -26,33 +26,31 @@ import (
 
 // NewServiceAccountControl returns a new instance of the ServiceAccount controller
 func NewServiceAccountControl(config ServiceAccountConfig) (*ServiceAccountControl, error) {
-	err := config.CheckAndSetDefaults()
+	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &ServiceAccountControl{
 		ServiceAccountConfig: config,
-		ServiceAccount:       config.Account,
-		Entry: log.WithFields(log.Fields{
-			"service_account": formatMeta(config.Account.ObjectMeta),
+		FieldLogger: log.WithFields(log.Fields{
+			"service_account": formatMeta(config.ObjectMeta),
 		}),
 	}, nil
 }
 
 // ServiceAccountConfig defines controller configuration
 type ServiceAccountConfig struct {
-	// Account is the existing service account
-	Account v1.ServiceAccount
+	// ServiceAccount is the existing service account
+	v1.ServiceAccount
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
-func (c *ServiceAccountConfig) CheckAndSetDefaults() error {
+func (c *ServiceAccountConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	c.Account.Kind = KindServiceAccount
-	c.Account.APIVersion = V1
+	updateTypeMetaServiceAccount(&c.ServiceAccount)
 	return nil
 }
 
@@ -60,8 +58,7 @@ func (c *ServiceAccountConfig) CheckAndSetDefaults() error {
 // adds various operations, like delete, status check and update
 type ServiceAccountControl struct {
 	ServiceAccountConfig
-	v1.ServiceAccount
-	*log.Entry
+	log.FieldLogger
 }
 
 func (c *ServiceAccountControl) Delete(ctx context.Context, cascade bool) error {
@@ -95,4 +92,11 @@ func (c *ServiceAccountControl) Status() error {
 	accounts := c.Client.Core().ServiceAccounts(c.Namespace)
 	_, err := accounts.Get(c.Name, metav1.GetOptions{})
 	return ConvertError(err)
+}
+
+func updateTypeMetaServiceAccount(r *v1.ServiceAccount) {
+	r.Kind = KindServiceAccount
+	if r.APIVersion == "" {
+		r.APIVersion = v1.SchemeGroupVersion.String()
+	}
 }

--- a/serviceaccount.go
+++ b/serviceaccount.go
@@ -41,16 +41,19 @@ func NewServiceAccountControl(config ServiceAccountConfig) (*ServiceAccountContr
 // ServiceAccountConfig defines controller configuration
 type ServiceAccountConfig struct {
 	// ServiceAccount is the existing service account
-	v1.ServiceAccount
+	*v1.ServiceAccount
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
 func (c *ServiceAccountConfig) checkAndSetDefaults() error {
+	if c.ServiceAccount == nil {
+		return trace.BadParameter("missing parameter ServiceAccount")
+	}
 	if c.Client == nil {
 		return trace.BadParameter("missing parameter Client")
 	}
-	updateTypeMetaServiceAccount(&c.ServiceAccount)
+	updateTypeMetaServiceAccount(c.ServiceAccount)
 	return nil
 }
 
@@ -81,10 +84,10 @@ func (c *ServiceAccountControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		_, err = accounts.Create(&c.ServiceAccount)
+		_, err = accounts.Create(c.ServiceAccount)
 		return ConvertError(err)
 	}
-	_, err = accounts.Update(&c.ServiceAccount)
+	_, err = accounts.Update(c.ServiceAccount)
 	return ConvertError(err)
 }
 

--- a/statefulset.go
+++ b/statefulset.go
@@ -30,14 +30,13 @@ import (
 
 // NewStatefulSetControl returns new instance of the StatefulSet controller
 func NewStatefulSetControl(config StatefulSetConfig) (*StatefulSetControl, error) {
-	err := config.CheckAndSetDefaults()
+	err := config.checkAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	return &StatefulSetControl{
 		StatefulSetConfig: config,
-		Entry: log.WithFields(log.Fields{
+		FieldLogger: log.WithFields(log.Fields{
 			"statefulset": formatMeta(config.StatefulSet.ObjectMeta),
 		}),
 	}, nil
@@ -46,28 +45,25 @@ func NewStatefulSetControl(config StatefulSetConfig) (*StatefulSetControl, error
 // StatefulSetConfig is a StatefulSet control configuration
 type StatefulSetConfig struct {
 	// StatefulSet is already parsed statefulset
-	*appsv1.StatefulSet
+	appsv1.StatefulSet
 	// Client is k8s client
 	Client *kubernetes.Clientset
 }
 
-// CheckAndSetDefaults validates this configuration object and sets defaults
-func (c *StatefulSetConfig) CheckAndSetDefaults() error {
-	var errors []error
-	if c.StatefulSet == nil {
-		errors = append(errors, trace.BadParameter("missing parameter StatefulSet"))
-	}
+// checkAndSetDefaults validates this configuration object and sets defaults
+func (c *StatefulSetConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
-		errors = append(errors, trace.BadParameter("missing parameter Client"))
+		return trace.BadParameter("missing parameter Client")
 	}
-	return trace.NewAggregate(errors...)
+	updateTypeMetaStatefulSet(&c.StatefulSet)
+	return nil
 }
 
 // StatefulSetControl is a statefulset controller,
 // adds various operations, like delete, status check and update
 type StatefulSetControl struct {
 	StatefulSetConfig
-	*log.Entry
+	log.FieldLogger
 }
 
 // Upsert creates or updates a statefulset resource
@@ -85,7 +81,7 @@ func (c *StatefulSetControl) Upsert(ctx context.Context) error {
 	}
 
 	if currentResource != nil {
-		control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: currentResource, Client: c.Client})
+		control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: *currentResource, Client: c.Client})
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -102,7 +98,7 @@ func (c *StatefulSetControl) Upsert(ctx context.Context) error {
 	c.StatefulSet.ResourceVersion = ""
 
 	err = withExponentialBackoff(func() error {
-		_, err = collection.Create(c.StatefulSet)
+		_, err = collection.Create(&c.StatefulSet)
 		return ConvertError(err)
 	})
 	return trace.Wrap(err)
@@ -115,7 +111,7 @@ func (c *StatefulSetControl) collectPods(statefulSet *appsv1.StatefulSet) (map[s
 	if statefulSet.Spec.Selector != nil {
 		labels = statefulSet.Spec.Selector.MatchLabels
 	}
-	pods, err := CollectPods(statefulSet.Namespace, labels, c.Entry, c.Client, func(ref metav1.OwnerReference) bool {
+	pods, err := CollectPods(statefulSet.Namespace, labels, c.FieldLogger, c.Client, func(ref metav1.OwnerReference) bool {
 		return ref.Kind == KindStatefulSet && ref.UID == statefulSet.UID
 	})
 	return pods, trace.Wrap(err)
@@ -157,7 +153,7 @@ func (c *StatefulSetControl) Delete(ctx context.Context, cascade bool) error {
 	if !cascade {
 		c.Debug("Cascade not set, returning.")
 	}
-	err = deletePods(pods, currentPods, *c.Entry)
+	err = deletePods(pods, currentPods, c.FieldLogger)
 	return trace.Wrap(err)
 }
 
@@ -187,5 +183,12 @@ func (c *StatefulSetControl) Status() error {
 	if err != nil {
 		return ConvertError(err)
 	}
-	return checkRunning(currentPods, nodes.Items, c.Entry)
+	return checkRunning(currentPods, nodes.Items, c.FieldLogger)
+}
+
+func updateTypeMetaStatefulSet(r *appsv1.StatefulSet) {
+	r.Kind = KindStatefulSet
+	if r.APIVersion == "" {
+		r.APIVersion = appsv1.SchemeGroupVersion.String()
+	}
 }

--- a/tool/rig/main.go
+++ b/tool/rig/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"text/tabwriter"
 	"time"
@@ -301,7 +300,7 @@ func status(ctx context.Context, client *kubernetes.Clientset, config *rest.Conf
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		updater, err := rigging.NewDSControl(rigging.DSConfig{
+		updater, err := rigging.NewDaemonSetControl(rigging.DSConfig{
 			DaemonSet: daemonSet,
 			Client:    client,
 		})
@@ -328,8 +327,6 @@ func status(ctx context.Context, client *kubernetes.Clientset, config *rest.Conf
 
 const (
 	outputYAML = "yaml"
-	outputText = "text"
-	outputJSON = "json"
 	// humanDateFormat is a human readable date formatting
 	humanDateFormat = "Mon Jan _2 15:04 UTC"
 	changesetEnvVar = "RIG_CHANGESET"
@@ -424,10 +421,6 @@ func csDelete(ctx context.Context, client *kubernetes.Clientset, config *rest.Co
 	return nil
 }
 
-func printHeader(val string) {
-	fmt.Printf("\n[%v]\n%v\n", val, strings.Repeat("-", len(val)+2))
-}
-
 // InitLoggerCLI tools by default log into syslog, not stderr
 func InitLoggerCLI() {
 	log.SetLevel(log.WarnLevel)
@@ -459,11 +452,6 @@ func TurnOffLogging() {
 	log.SetOutput(ioutil.Discard)
 	log.SetLevel(log.FatalLevel)
 }
-
-const (
-	inCluster  = "in"
-	outCluster = "out"
-)
 
 // NormalizePath normalises path, evaluating symlinks and converting local
 // paths to absolute

--- a/tool/rig/main.go
+++ b/tool/rig/main.go
@@ -302,7 +302,7 @@ func status(ctx context.Context, client *kubernetes.Clientset, config *rest.Conf
 			return trace.Wrap(err)
 		}
 		updater, err := rigging.NewDSControl(rigging.DSConfig{
-			DaemonSet: ds,
+			DaemonSet: *ds,
 			Client:    client,
 		})
 		if err != nil {
@@ -315,7 +315,7 @@ func status(ctx context.Context, client *kubernetes.Clientset, config *rest.Conf
 			return trace.Wrap(err)
 		}
 		updater, err := rigging.NewDeploymentControl(rigging.DeploymentConfig{
-			Deployment: deployment,
+			Deployment: *deployment,
 			Client:     client,
 		})
 		if err != nil {

--- a/tool/rig/main.go
+++ b/tool/rig/main.go
@@ -297,12 +297,12 @@ func status(ctx context.Context, client *kubernetes.Clientset, config *rest.Conf
 		fmt.Printf("no errors detected for %v\n", resource.Name)
 		return nil
 	case rigging.KindDaemonSet:
-		ds, err := client.Apps().DaemonSets(namespace).Get(resource.Name, metav1.GetOptions{})
+		daemonSet, err := client.Apps().DaemonSets(namespace).Get(resource.Name, metav1.GetOptions{})
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		updater, err := rigging.NewDSControl(rigging.DSConfig{
-			DaemonSet: *ds,
+			DaemonSet: daemonSet,
 			Client:    client,
 		})
 		if err != nil {
@@ -315,7 +315,7 @@ func status(ctx context.Context, client *kubernetes.Clientset, config *rest.Conf
 			return trace.Wrap(err)
 		}
 		updater, err := rigging.NewDeploymentControl(rigging.DeploymentConfig{
-			Deployment: *deployment,
+			Deployment: deployment,
 			Client:     client,
 		})
 		if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -95,7 +95,7 @@ func PollStatus(ctx context.Context, retryAttempts int, retryPeriod time.Duratio
 }
 
 // CollectPods collects pods matched by fn
-func CollectPods(namespace string, matchLabels map[string]string, entry *log.Entry, client *kubernetes.Clientset,
+func CollectPods(namespace string, matchLabels map[string]string, logger log.FieldLogger, client *kubernetes.Clientset,
 	fn func(metav1.OwnerReference) bool) (map[string]v1.Pod, error) {
 	set := make(labels.Set)
 	for key, val := range matchLabels {
@@ -114,7 +114,7 @@ func CollectPods(namespace string, matchLabels map[string]string, entry *log.Ent
 		for _, ref := range pod.OwnerReferences {
 			if fn(ref) {
 				pods[pod.Spec.NodeName] = pod
-				entry.Infof("found pod %v on node %v", formatMeta(pod.ObjectMeta), pod.Spec.NodeName)
+				logger.Infof("found pod %v on node %v", formatMeta(pod.ObjectMeta), pod.Spec.NodeName)
 			}
 		}
 	}
@@ -171,30 +171,30 @@ func nodeSelector(spec *v1.PodSpec) labels.Selector {
 	return set.AsSelector()
 }
 
-func checkRunning(pods map[string]v1.Pod, nodes []v1.Node, entry *log.Entry) error {
-	ready, err := checkRunningAndReady(pods, nodes, entry)
+func checkRunning(pods map[string]v1.Pod, nodes []v1.Node, logger log.FieldLogger) error {
+	ready, err := checkRunningAndReady(pods, nodes, logger)
 	if ready || err == errPodCompleted {
 		return nil
 	}
 	return trace.Wrap(err)
 }
 
-func checkRunningAndReady(pods map[string]v1.Pod, nodes []v1.Node, entry *log.Entry) (bool, error) {
+func checkRunningAndReady(pods map[string]v1.Pod, nodes []v1.Node, logger log.FieldLogger) (bool, error) {
 	for _, node := range nodes {
 		pod, ok := pods[node.Name]
 		if !ok {
-			entry.Infof("no pod found on node %v", node.Name)
+			logger.Infof("no pod found on node %v", node.Name)
 			return false, trace.NotFound("no pod found on node %v", node.Name)
 		}
 		meta := formatMeta(pod.ObjectMeta)
 		switch pod.Status.Phase {
 		case v1.PodFailed, v1.PodSucceeded:
-			entry.Infof("node %v: pod %v is %q", node.Name, meta, pod.Status.Phase)
+			logger.Infof("node %v: pod %v is %q", node.Name, meta, pod.Status.Phase)
 			return false, errPodCompleted
 		case v1.PodRunning:
 			ready := isPodReadyConditionTrue(pod.Status)
 			if ready {
-				entry.Infof("node %v: pod %v is up and running", node.Name, meta)
+				logger.Infof("node %v: pod %v is up and running", node.Name, meta)
 			}
 			return ready, nil
 		default:
@@ -299,31 +299,31 @@ func withExponentialBackoff(fn func() error) error {
 	return trace.Wrap(err)
 }
 
-func deletePodsList(podIface corev1.PodInterface, pods []v1.Pod, entry log.Entry) error {
+func deletePodsList(podIface corev1.PodInterface, pods []v1.Pod, logger log.FieldLogger) error {
 	for _, pod := range pods {
-		entry.Debugf("deleting pod %v", pod.Name)
+		logger.Debugf("deleting pod %v", pod.Name)
 		err := ConvertError(podIface.Delete(pod.Name, nil))
 		if err != nil && !trace.IsNotFound(err) {
 			return ConvertError(err)
 		}
 	}
 
-	return trace.Wrap(waitForPodsList(podIface, pods, entry))
+	return trace.Wrap(waitForPodsList(podIface, pods))
 }
 
-func deletePods(podIface corev1.PodInterface, pods map[string]v1.Pod, entry log.Entry) error {
+func deletePods(podIface corev1.PodInterface, pods map[string]v1.Pod, logger log.FieldLogger) error {
 	for _, pod := range pods {
-		entry.Debugf("deleting pod %v", pod.Name)
+		logger.Debugf("deleting pod %v", pod.Name)
 		err := ConvertError(podIface.Delete(pod.Name, nil))
 		if err != nil && !trace.IsNotFound(err) {
 			return ConvertError(err)
 		}
 	}
 
-	return trace.Wrap(waitForPods(podIface, pods, entry))
+	return trace.Wrap(waitForPods(podIface, pods))
 }
 
-func waitForPodsList(podIface corev1.PodInterface, pods []v1.Pod, entry log.Entry) error {
+func waitForPodsList(podIface corev1.PodInterface, pods []v1.Pod) error {
 	var errors []error
 	for _, pod := range pods {
 		err := waitForObjectDeletion(func() error {
@@ -337,7 +337,7 @@ func waitForPodsList(podIface corev1.PodInterface, pods []v1.Pod, entry log.Entr
 	return trace.NewAggregate(errors...)
 }
 
-func waitForPods(podIface corev1.PodInterface, pods map[string]v1.Pod, entry log.Entry) error {
+func waitForPods(podIface corev1.PodInterface, pods map[string]v1.Pod) error {
 	var errors []error
 	for _, pod := range pods {
 		err := waitForObjectDeletion(func() error {


### PR DESCRIPTION
 * Update resource implementations to be consistent.
 * Correct empty `TypeMeta` on upsert/delete to avoid `changeset` status to fail to determine the resource type when de-serialized from text.

Fixes https://github.com/gravitational/gravity.e/issues/3986.