### PR TITLE
Noop upsert for completed changeset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 
 .PHONY: test
 test:
-	go test -v -test.parallel=0 ./ ./tool/...
+	go test -v -test.parallel=1 ./ ./tool/...
 
 BUILDBOX := quay.io/gravitational/debian-venti:go1.12.9-buster
 
@@ -60,7 +60,6 @@ docker-image:
 .PHONY: publish-docker-image
 publish-docker-image:
 	docker push $(IMAGE)
-
 
 .PHONY: print-image
 print-image:

--- a/changeset.go
+++ b/changeset.go
@@ -113,8 +113,7 @@ func NewChangeset(ctx context.Context, config ChangesetConfig) (*Changeset, erro
 	return cs, nil
 }
 
-// Changeset is a is a collection changeset log that can revert a series of
-// changes to the system
+// Changeset manages changes to a series of Kubernetes resources
 type Changeset struct {
 	ChangesetConfig
 	client *rest.RESTClient
@@ -208,6 +207,18 @@ func (cs *Changeset) upsertResource(ctx context.Context, changesetNamespace, cha
 		return trace.BadParameter("unsupported resource type %v", kind.Kind)
 	}
 	return err
+}
+
+// IsCommitted returns whether this changeset has already been committed
+func (cs *Changeset) IsCommitted(ctx context.Context, changesetNamespace, changesetName string) (completed bool, err error) {
+	res, err := cs.get(changesetNamespace, changesetName)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	if res.Spec.Status != ChangesetStatusCommitted {
+		return false, nil
+	}
+	return true, nil
 }
 
 // Status checks all statuses for all resources updated or added in the context of a given changeset


### PR DESCRIPTION
This PR implements a change to support noop `rig upsert/freeze` for completed changesets - otherwise, the commands would fail expecting the changeset to be in-progress.