### PR TITLE
Use Debian Stretch as a source image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 test:
 	go test -v -test.parallel=0 ./ ./tool/...
 
-BUILDBOX := quay.io/gravitational/debian-venti:go1.12.9-buster
+BUILDBOX := quay.io/gravitational/debian-venti:go1.12.17-stretch
 
 # Directory with sources inside the container
 DST := /gopath/src/github.com/gravitational/rigging

--- a/docker/rig.dockerfile
+++ b/docker/rig.dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/debian-grande:buster
+FROM quay.io/gravitational/debian-grande:stretch
 
 ADD ./build/rig /usr/local/bin/rig
 RUN chmod +x /usr/local/bin/rig


### PR DESCRIPTION
Use Debian Stretch to prevent any potential compatibility problems
with distributions like RH7.