### PR TITLE
Collect replica sets

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -185,8 +185,8 @@ func (c *DeploymentControl) collectPods(deployment *appsv1.Deployment) (map[stri
 		if err != nil {
 			return nil, ConvertError(err)
 		}
-		for nodename, pod := range podMap {
-			pods[nodename] = pod
+		for _, pod := range podMap {
+			pods[pod.ObjectMeta.Name] = pod
 		}
 	}
 	return pods, nil

--- a/deployment.go
+++ b/deployment.go
@@ -177,7 +177,7 @@ func (c *DeploymentControl) collectPods(deployment *appsv1.Deployment) (map[stri
 		return nil, ConvertError(err)
 	}
 
-	pods := make(map[string]v1.Pod, 0)
+	pods := make(map[string]v1.Pod)
 	for _, replicaSet := range replicaSets {
 		podMap, err := CollectPods(replicaSet.Namespace, labels, c.FieldLogger, c.Client, func(ref metav1.OwnerReference) bool {
 			return ref.Kind == KindReplicaSet && ref.UID == replicaSet.UID

--- a/utils.go
+++ b/utils.go
@@ -13,6 +13,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -114,13 +115,46 @@ func CollectPods(namespace string, matchLabels map[string]string, logger log.Fie
 		for _, ref := range pod.OwnerReferences {
 			if fn(ref) {
 				pods[pod.Spec.NodeName] = pod
-				logger.Infof("found pod %v on node %v", formatMeta(pod.ObjectMeta), pod.Spec.NodeName)
+				logger.WithFields(log.Fields{
+					"pod":  pod.ObjectMeta.Name,
+					"node": pod.Spec.NodeName,
+				}).Info("Found pod on node.")
 			}
 		}
 	}
 	return pods, nil
 }
 
+// CollectReplicaSets collects replicasets matched by fn
+func CollectReplicaSets(namespace string, matchLabels map[string]string, logger log.FieldLogger, client *kubernetes.Clientset,
+	fn func(metav1.OwnerReference) bool) ([]v1beta1.ReplicaSet, error) {
+	set := make(labels.Set)
+	for key, val := range matchLabels {
+		set[key] = val
+	}
+
+	rsList, err := client.ExtensionsV1beta1().ReplicaSets(namespace).List(metav1.ListOptions{
+		LabelSelector: set.AsSelector().String(),
+	})
+	if err != nil {
+		return nil, ConvertError(err)
+	}
+
+	var replicaSets []v1beta1.ReplicaSet
+	for _, replicaSet := range rsList.Items {
+		for _, ref := range replicaSet.OwnerReferences {
+			if fn(ref) {
+				replicaSets = append(replicaSets, replicaSet)
+				logger.WithFields(log.Fields{
+					"replicaset": replicaSet.ObjectMeta.Name,
+					"deployment": ref.Name,
+					"UID":        ref.UID,
+				}).Info("Found ReplicaSet owned by deployment.")
+			}
+		}
+	}
+	return replicaSets, nil
+}
 func retry(ctx context.Context, times int, period time.Duration, fn func() error) error {
 	if times < 1 {
 		return nil

--- a/utils.go
+++ b/utils.go
@@ -110,14 +110,15 @@ func CollectPods(namespace string, matchLabels map[string]string, logger log.Fie
 		return nil, ConvertError(err)
 	}
 
-	pods := make(map[string]v1.Pod, 0)
+	pods := make(map[string]v1.Pod)
 	for _, pod := range podList.Items {
 		for _, ref := range pod.OwnerReferences {
 			if fn(ref) {
 				pods[pod.Spec.NodeName] = pod
 				logger.WithFields(log.Fields{
-					"pod":  pod.ObjectMeta.Name,
-					"node": pod.Spec.NodeName,
+					"pod":       pod.ObjectMeta.GetName(),
+					"node":      pod.Spec.NodeName,
+					"namespace": pod.ObjectMeta.GetNamespace(),
 				}).Info("Found pod on node.")
 			}
 		}
@@ -146,9 +147,10 @@ func CollectReplicaSets(namespace string, matchLabels map[string]string, logger 
 			if fn(ref) {
 				replicaSets = append(replicaSets, replicaSet)
 				logger.WithFields(log.Fields{
-					"replicaset": replicaSet.ObjectMeta.Name,
+					"replicaset": replicaSet.ObjectMeta.GetName(),
 					"deployment": ref.Name,
 					"UID":        ref.UID,
+					"namespace":  replicaSet.ObjectMeta.GetNamespace(),
 				}).Info("Found ReplicaSet owned by deployment.")
 			}
 		}


### PR DESCRIPTION
This PR fixes the issue with the collection of pods behind deployments. [This function](https://github.com/gravitational/rigging/blob/version/5.5.x/deployment.go#L173) returns 0 pods because pods are referenced to ReplicaSet, not Deployment.

The new approach here to find all ReplicaSets owned by Deployment and collect pods based on those ReplicaSets UIDs.

I am still not sure how it will work with pods during a Deployment rolling upgrade.