### PR TITLE
Feature: customer override-able configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 
 .PHONY: test
 test:
-	go test -v -test.parallel=0 ./ ./tool/...
+	go test -v ./ ./tool/...
 
 BUILDBOX := quay.io/gravitational/debian-venti:go1.12.9-buster
 

--- a/alertmanager.go
+++ b/alertmanager.go
@@ -88,7 +88,7 @@ func (c *AlertmanagerControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(currentAlertmanager.Annotations) {
-		c.WithField("alertmanager", formatMeta(c.Alertmanager.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("alertmanager", formatMeta(c.Alertmanager.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/alertmanager.go
+++ b/alertmanager.go
@@ -86,6 +86,12 @@ func (c *AlertmanagerControl) Upsert(ctx context.Context) error {
 		_, err = client.Create(c.Alertmanager)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(currentAlertmanager.Annotations) {
+		c.WithField("alertmanager", formatMeta(c.Alertmanager.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	c.Alertmanager.ResourceVersion = currentAlertmanager.ResourceVersion
 	_, err = client.Update(c.Alertmanager)
 	return ConvertError(err)

--- a/apiservice.go
+++ b/apiservice.go
@@ -89,7 +89,7 @@ func (c *APIServiceControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(currentAPIService.Annotations) {
-		c.WithField("apiservice", formatMeta(c.APIService.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("apiservice", formatMeta(c.APIService.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/apiservice.go
+++ b/apiservice.go
@@ -87,6 +87,12 @@ func (c *APIServiceControl) Upsert(ctx context.Context) error {
 		_, err = client.Create(c.APIService)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(currentAPIService.Annotations) {
+		c.WithField("apiservice", formatMeta(c.APIService.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	c.APIService.ResourceVersion = currentAPIService.ResourceVersion
 	_, err = client.Update(c.APIService)
 	return ConvertError(err)

--- a/configmap.go
+++ b/configmap.go
@@ -78,7 +78,7 @@ func (c *ConfigMapControl) Upsert(ctx context.Context) error {
 	c.ConfigMap.UID = ""
 	c.ConfigMap.SelfLink = ""
 	c.ConfigMap.ResourceVersion = ""
-	_, err := configMaps.Get(c.ConfigMap.Name, metav1.GetOptions{})
+	currentConfigMap, err := configMaps.Get(c.ConfigMap.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -87,6 +87,12 @@ func (c *ConfigMapControl) Upsert(ctx context.Context) error {
 		_, err = configMaps.Create(c.ConfigMap)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(currentConfigMap.Annotations) {
+		c.WithField("configmap", formatMeta(c.ConfigMap.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	_, err = configMaps.Update(c.ConfigMap)
 	return ConvertError(err)
 }

--- a/configmap.go
+++ b/configmap.go
@@ -89,7 +89,7 @@ func (c *ConfigMapControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(currentConfigMap.Annotations) {
-		c.WithField("configmap", formatMeta(c.ConfigMap.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("configmap", formatMeta(c.ConfigMap.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/constants.go
+++ b/constants.go
@@ -58,8 +58,10 @@ const (
 
 	ChangesetAPIVersion = "changeset.gravitational.io/v1"
 
-	// CustomerManagedAnnotation specifies an annotation that will cause rigging to not overwrite an object that is
-	// already present in kubernetes if the annotation is already present on the object.
+	// CustomerManagedAnnotation specifies an annotation that a customer can use to take control of a kubernetes object
+	// that is normally managed via gravity/rigging. If rigging see's this annotation on an object, it will no longer
+	// update the object to the current desired state. Insert / Delete operations will still proceed however. This
+	// is mainly so that a customer can take over and customize configuration built into gravity.
 	CustomerManagedAnnotation = "gravitational.io/customer-managed"
 )
 

--- a/constants.go
+++ b/constants.go
@@ -57,6 +57,10 @@ const (
 	DefaultBufferSize  = 1024
 
 	ChangesetAPIVersion = "changeset.gravitational.io/v1"
+
+	// CustomerManagedAnnotation specifies an annotation that will cause rigging to not overwrite an object that is
+	// already present in kubernetes if the annotation is already present on the object.
+	CustomerManagedAnnotation = "gravitational.io/customer-managed"
 )
 
 // Namespace returns a default namespace if the specified namespace is empty

--- a/constants.go
+++ b/constants.go
@@ -59,7 +59,7 @@ const (
 	ChangesetAPIVersion = "changeset.gravitational.io/v1"
 
 	// CustomerManagedAnnotation specifies an annotation that a customer can use to take control of a kubernetes object
-	// that is normally managed via gravity/rigging. If rigging see's this annotation on an object, it will no longer
+	// that is normally managed via gravity/rigging. If rigging sees this annotation on an object, it will no longer
 	// update the object to the current desired state. Insert / Delete operations will still proceed however. This
 	// is mainly so that a customer can take over and customize configuration built into gravity.
 	CustomerManagedAnnotation = "gravitational.io/customer-managed"

--- a/crd.go
+++ b/crd.go
@@ -90,6 +90,12 @@ func (c *CustomResourceDefinitionControl) Upsert(ctx context.Context) error {
 		_, err = CustomResourceDefinitions.Create(c.CustomResourceDefinition)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(existing.Annotations) {
+		c.WithField("customresourcedefinition", formatMeta(c.CustomResourceDefinition.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	c.CustomResourceDefinition.ResourceVersion = existing.ResourceVersion
 	_, err = CustomResourceDefinitions.Update(c.CustomResourceDefinition)
 	return ConvertError(err)

--- a/crd.go
+++ b/crd.go
@@ -92,7 +92,7 @@ func (c *CustomResourceDefinitionControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(existing.Annotations) {
-		c.WithField("customresourcedefinition", formatMeta(c.CustomResourceDefinition.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("customresourcedefinition", formatMeta(c.CustomResourceDefinition.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/deployment.go
+++ b/deployment.go
@@ -122,7 +122,7 @@ func (c *DeploymentControl) Upsert(ctx context.Context) error {
 	c.Deployment.UID = ""
 	c.Deployment.SelfLink = ""
 	c.Deployment.ResourceVersion = ""
-	_, err := deployments.Get(c.Deployment.Name, metav1.GetOptions{})
+	existing, err := deployments.Get(c.Deployment.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -131,6 +131,12 @@ func (c *DeploymentControl) Upsert(ctx context.Context) error {
 		_, err = deployments.Create(c.Deployment)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(existing.Annotations) {
+		c.WithField("deploy", formatMeta(c.Deployment.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	_, err = deployments.Update(c.Deployment)
 	return ConvertError(err)
 }

--- a/deployment.go
+++ b/deployment.go
@@ -133,7 +133,7 @@ func (c *DeploymentControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(existing.Annotations) {
-		c.WithField("deploy", formatMeta(c.Deployment.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("deploy", formatMeta(c.Deployment.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/ds.go
+++ b/ds.go
@@ -131,6 +131,11 @@ func (c *DSControl) Upsert(ctx context.Context) error {
 	}
 
 	if currentDS != nil {
+		if checkCustomerManagedResource(currentDS.Annotations) {
+			c.WithField("daemonset", formatMeta(c.DaemonSet.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+			return nil
+		}
+
 		control, err := NewDaemonSetControl(DSConfig{DaemonSet: currentDS, Client: c.Client})
 		if err != nil {
 			return trace.Wrap(err)

--- a/ds.go
+++ b/ds.go
@@ -132,7 +132,7 @@ func (c *DSControl) Upsert(ctx context.Context) error {
 
 	if currentDS != nil {
 		if checkCustomerManagedResource(currentDS.Annotations) {
-			c.WithField("daemonset", formatMeta(c.DaemonSet.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+			c.WithField("daemonset", formatMeta(c.DaemonSet.ObjectMeta)).Info("Skipping update since object is customer managed.")
 			return nil
 		}
 

--- a/job.go
+++ b/job.go
@@ -93,6 +93,11 @@ func (c *JobControl) Upsert(ctx context.Context) error {
 	}
 
 	if currentJob != nil {
+		if checkCustomerManagedResource(currentJob.Annotations) {
+			c.WithField("job", formatMeta(c.Job.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+			return nil
+		}
+
 		control, err := NewJobControl(JobConfig{Job: currentJob, Clientset: c.Clientset})
 		if err != nil {
 			return ConvertError(err)

--- a/job.go
+++ b/job.go
@@ -94,7 +94,7 @@ func (c *JobControl) Upsert(ctx context.Context) error {
 
 	if currentJob != nil {
 		if checkCustomerManagedResource(currentJob.Annotations) {
-			c.WithField("job", formatMeta(c.Job.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+			c.WithField("job", formatMeta(c.Job.ObjectMeta)).Info("Skipping update since object is customer managed.")
 			return nil
 		}
 

--- a/namespace.go
+++ b/namespace.go
@@ -80,7 +80,7 @@ func (c *NamespaceControl) Upsert(ctx context.Context) error {
 	c.Namespace.UID = ""
 	c.Namespace.SelfLink = ""
 	c.Namespace.ResourceVersion = ""
-	_, err := Namespaces.Get(c.Namespace.Name, metav1.GetOptions{})
+	existing, err := Namespaces.Get(c.Namespace.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -89,6 +89,12 @@ func (c *NamespaceControl) Upsert(ctx context.Context) error {
 		_, err = Namespaces.Create(c.Namespace)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(existing.Annotations) {
+		c.WithField("namespace", formatMeta(c.Namespace.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	_, err = Namespaces.Update(c.Namespace)
 	return ConvertError(err)
 }

--- a/namespace.go
+++ b/namespace.go
@@ -91,7 +91,7 @@ func (c *NamespaceControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(existing.Annotations) {
-		c.WithField("namespace", formatMeta(c.Namespace.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("namespace", formatMeta(c.Namespace.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/policies.go
+++ b/policies.go
@@ -78,7 +78,7 @@ func (c *PodSecurityPolicyControl) Upsert(ctx context.Context) error {
 	c.UID = ""
 	c.SelfLink = ""
 	c.ResourceVersion = ""
-	_, err := policies.Get(c.Name, metav1.GetOptions{})
+	existing, err := policies.Get(c.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -87,6 +87,12 @@ func (c *PodSecurityPolicyControl) Upsert(ctx context.Context) error {
 		_, err = policies.Create(c.PodSecurityPolicy)
 		return ConvertErrorWithContext(err, "cannot create pod security policy %q", formatMeta(c.ObjectMeta))
 	}
+
+	if checkCustomerManagedResource(existing.Annotations) {
+		c.WithField("psp", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	_, err = policies.Update(c.PodSecurityPolicy)
 	return ConvertError(err)
 }

--- a/policies.go
+++ b/policies.go
@@ -89,7 +89,7 @@ func (c *PodSecurityPolicyControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(existing.Annotations) {
-		c.WithField("psp", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("psp", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/priorityclass.go
+++ b/priorityclass.go
@@ -92,7 +92,7 @@ func (c *PriorityClassControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(existing.Annotations) {
-		c.WithField("priorityclass", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("priorityclass", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/priorityclass.go
+++ b/priorityclass.go
@@ -81,7 +81,7 @@ func (c *PriorityClassControl) Upsert(ctx context.Context) error {
 	c.PriorityClass.UID = ""
 	c.PriorityClass.SelfLink = ""
 	c.PriorityClass.ResourceVersion = ""
-	_, err := PriorityClasss.Get(c.PriorityClass.Name, metav1.GetOptions{})
+	existing, err := PriorityClasss.Get(c.PriorityClass.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -90,6 +90,12 @@ func (c *PriorityClassControl) Upsert(ctx context.Context) error {
 		_, err = PriorityClasss.Create(c.PriorityClass)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(existing.Annotations) {
+		c.WithField("priorityclass", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	_, err = PriorityClasss.Update(c.PriorityClass)
 	return ConvertError(err)
 }

--- a/prometheus.go
+++ b/prometheus.go
@@ -86,6 +86,12 @@ func (c *PrometheusControl) Upsert(ctx context.Context) error {
 		_, err = client.Create(c.Prometheus)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(currentPrometheus.Annotations) {
+		c.WithField("prometheus", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	c.Prometheus.ResourceVersion = currentPrometheus.ResourceVersion
 	_, err = client.Update(c.Prometheus)
 	return ConvertError(err)

--- a/prometheus.go
+++ b/prometheus.go
@@ -88,7 +88,7 @@ func (c *PrometheusControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(currentPrometheus.Annotations) {
-		c.WithField("prometheus", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("prometheus", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/prometheusrule.go
+++ b/prometheusrule.go
@@ -86,6 +86,12 @@ func (c *PrometheusRuleControl) Upsert(ctx context.Context) error {
 		_, err = client.Create(c.PrometheusRule)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(currentRule.Annotations) {
+		c.WithField("prometheusrule", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	c.PrometheusRule.ResourceVersion = currentRule.ResourceVersion
 	_, err = client.Update(c.PrometheusRule)
 	return ConvertError(err)

--- a/prometheusrule.go
+++ b/prometheusrule.go
@@ -88,7 +88,7 @@ func (c *PrometheusRuleControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(currentRule.Annotations) {
-		c.WithField("prometheusrule", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("prometheusrule", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/rcc.go
+++ b/rcc.go
@@ -131,6 +131,11 @@ func (c *RCControl) Upsert(ctx context.Context) error {
 	}
 
 	if currentRC != nil {
+		if checkCustomerManagedResource(currentRC.Annotations) {
+			c.WithField("replicationcontroller", formatMeta(c.ReplicationController.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+			return nil
+		}
+
 		control, err := NewReplicationControllerControl(RCConfig{ReplicationController: currentRC, Client: c.Client})
 		if err != nil {
 			return ConvertError(err)

--- a/rcc.go
+++ b/rcc.go
@@ -132,7 +132,7 @@ func (c *RCControl) Upsert(ctx context.Context) error {
 
 	if currentRC != nil {
 		if checkCustomerManagedResource(currentRC.Annotations) {
-			c.WithField("replicationcontroller", formatMeta(c.ReplicationController.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+			c.WithField("replicationcontroller", formatMeta(c.ReplicationController.ObjectMeta)).Info("Skipping update since object is customer managed.")
 			return nil
 		}
 

--- a/roles.go
+++ b/roles.go
@@ -89,7 +89,7 @@ func (c *RoleControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(existing.Annotations) {
-		c.WithField("role", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("role", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 
@@ -168,7 +168,7 @@ func (c *ClusterRoleControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(existing.Annotations) {
-		c.WithField("clusterrole", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("clusterrole", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 
@@ -247,7 +247,7 @@ func (c *RoleBindingControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(existing.Annotations) {
-		c.WithField("rolebinding", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("rolebinding", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 
@@ -326,7 +326,7 @@ func (c *ClusterRoleBindingControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(existing.Annotations) {
-		c.WithField("clusterrolebinding", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("clusterrolebinding", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/roles.go
+++ b/roles.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -78,7 +78,7 @@ func (c *RoleControl) Upsert(ctx context.Context) error {
 	c.UID = ""
 	c.SelfLink = ""
 	c.ResourceVersion = ""
-	_, err := roles.Get(c.Name, metav1.GetOptions{})
+	existing, err := roles.Get(c.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -87,6 +87,12 @@ func (c *RoleControl) Upsert(ctx context.Context) error {
 		_, err = roles.Create(c.Role)
 		return ConvertErrorWithContext(err, "cannot create role %q", formatMeta(c.ObjectMeta))
 	}
+
+	if checkCustomerManagedResource(existing.Annotations) {
+		c.WithField("role", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	_, err = roles.Update(c.Role)
 	return ConvertError(err)
 }
@@ -151,7 +157,7 @@ func (c *ClusterRoleControl) Upsert(ctx context.Context) error {
 	c.UID = ""
 	c.SelfLink = ""
 	c.ResourceVersion = ""
-	_, err := roles.Get(c.Name, metav1.GetOptions{})
+	existing, err := roles.Get(c.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -160,6 +166,12 @@ func (c *ClusterRoleControl) Upsert(ctx context.Context) error {
 		_, err = roles.Create(c.ClusterRole)
 		return ConvertErrorWithContext(err, "cannot create cluster role %q", formatMeta(c.ObjectMeta))
 	}
+
+	if checkCustomerManagedResource(existing.Annotations) {
+		c.WithField("clusterrole", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	_, err = roles.Update(c.ClusterRole)
 	return ConvertError(err)
 }
@@ -224,7 +236,7 @@ func (c *RoleBindingControl) Upsert(ctx context.Context) error {
 	c.UID = ""
 	c.SelfLink = ""
 	c.ResourceVersion = ""
-	_, err := bindings.Get(c.Name, metav1.GetOptions{})
+	existing, err := bindings.Get(c.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -233,6 +245,12 @@ func (c *RoleBindingControl) Upsert(ctx context.Context) error {
 		_, err = bindings.Create(c.RoleBinding)
 		return ConvertErrorWithContext(err, "cannot create role binding %q", formatMeta(c.ObjectMeta))
 	}
+
+	if checkCustomerManagedResource(existing.Annotations) {
+		c.WithField("rolebinding", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	_, err = bindings.Update(c.RoleBinding)
 	return ConvertError(err)
 }
@@ -297,7 +315,7 @@ func (c *ClusterRoleBindingControl) Upsert(ctx context.Context) error {
 	c.UID = ""
 	c.SelfLink = ""
 	c.ResourceVersion = ""
-	_, err := bindings.Get(c.Name, metav1.GetOptions{})
+	existing, err := bindings.Get(c.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -306,6 +324,12 @@ func (c *ClusterRoleBindingControl) Upsert(ctx context.Context) error {
 		_, err = bindings.Create(c.ClusterRoleBinding)
 		return ConvertErrorWithContext(err, "cannot create cluster role binding %q", formatMeta(c.ObjectMeta))
 	}
+
+	if checkCustomerManagedResource(existing.Annotations) {
+		c.WithField("clusterrolebinding", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	_, err = bindings.Update(c.ClusterRoleBinding)
 	return ConvertError(err)
 }

--- a/secret.go
+++ b/secret.go
@@ -78,7 +78,7 @@ func (c *SecretControl) Upsert(ctx context.Context) error {
 	c.Secret.UID = ""
 	c.Secret.SelfLink = ""
 	c.Secret.ResourceVersion = ""
-	_, err := secrets.Get(c.Secret.Name, metav1.GetOptions{})
+	existing, err := secrets.Get(c.Secret.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -87,6 +87,12 @@ func (c *SecretControl) Upsert(ctx context.Context) error {
 		_, err = secrets.Create(c.Secret)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(existing.Annotations) {
+		c.WithField("secret", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	_, err = secrets.Update(c.Secret)
 	return ConvertError(err)
 }

--- a/secret.go
+++ b/secret.go
@@ -89,7 +89,7 @@ func (c *SecretControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(existing.Annotations) {
-		c.WithField("secret", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("secret", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/service.go
+++ b/service.go
@@ -87,6 +87,12 @@ func (c *ServiceControl) Upsert(ctx context.Context) error {
 		_, err = services.Create(c.Service)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(currentService.Annotations) {
+		c.WithField("service", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	c.Service.Spec.ClusterIP = currentService.Spec.ClusterIP
 	c.Service.ResourceVersion = currentService.ResourceVersion
 	_, err = services.Update(c.Service)

--- a/service.go
+++ b/service.go
@@ -89,7 +89,7 @@ func (c *ServiceControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(currentService.Annotations) {
-		c.WithField("service", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("service", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/serviceaccount.go
+++ b/serviceaccount.go
@@ -89,7 +89,7 @@ func (c *ServiceAccountControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(existing.Annotations) {
-		c.WithField("serviceaccount", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("serviceaccount", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/serviceaccount.go
+++ b/serviceaccount.go
@@ -78,7 +78,7 @@ func (c *ServiceAccountControl) Upsert(ctx context.Context) error {
 	c.UID = ""
 	c.SelfLink = ""
 	c.ResourceVersion = ""
-	_, err := accounts.Get(c.Name, metav1.GetOptions{})
+	existing, err := accounts.Get(c.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -87,6 +87,12 @@ func (c *ServiceAccountControl) Upsert(ctx context.Context) error {
 		_, err = accounts.Create(c.ServiceAccount)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(existing.Annotations) {
+		c.WithField("serviceaccount", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	_, err = accounts.Update(c.ServiceAccount)
 	return ConvertError(err)
 }

--- a/servicemonitor.go
+++ b/servicemonitor.go
@@ -87,6 +87,12 @@ func (c *ServiceMonitorControl) Upsert(ctx context.Context) error {
 		_, err = serviceMonitorsClient.Create(c.ServiceMonitor)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(currentServiceMonitor.Annotations) {
+		c.WithField("servicemonitor", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	c.ServiceMonitor.ResourceVersion = currentServiceMonitor.ResourceVersion
 	_, err = serviceMonitorsClient.Update(c.ServiceMonitor)
 	return ConvertError(err)

--- a/servicemonitor.go
+++ b/servicemonitor.go
@@ -89,7 +89,7 @@ func (c *ServiceMonitorControl) Upsert(ctx context.Context) error {
 	}
 
 	if checkCustomerManagedResource(currentServiceMonitor.Annotations) {
-		c.WithField("servicemonitor", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("servicemonitor", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/statefulset.go
+++ b/statefulset.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -84,6 +84,11 @@ func (c *StatefulSetControl) Upsert(ctx context.Context) error {
 	}
 
 	if currentResource != nil {
+		if checkCustomerManagedResource(currentResource.Annotations) {
+			c.WithField("statefulset", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+			return nil
+		}
+
 		control, err := NewStatefulSetControl(StatefulSetConfig{StatefulSet: currentResource, Client: c.Client})
 		if err != nil {
 			return trace.Wrap(err)

--- a/statefulset.go
+++ b/statefulset.go
@@ -85,7 +85,7 @@ func (c *StatefulSetControl) Upsert(ctx context.Context) error {
 
 	if currentResource != nil {
 		if checkCustomerManagedResource(currentResource.Annotations) {
-			c.WithField("statefulset", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+			c.WithField("statefulset", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 			return nil
 		}
 

--- a/utils.go
+++ b/utils.go
@@ -368,3 +368,8 @@ const (
 	deletePollInterval = 1 * time.Second
 	deleteTimeout      = 5 * time.Minute
 )
+
+func checkCustomerManagedResource(annotations map[string]string) bool {
+	_, ok := annotations[CustomerManagedAnnotation]
+	return ok
+}

--- a/webhook.go
+++ b/webhook.go
@@ -87,7 +87,7 @@ func (c *ValidatingWebhookConfigurationControl) Upsert(ctx context.Context) erro
 	}
 
 	if checkCustomerManagedResource(currentWebhook.Annotations) {
-		c.WithField("webhook", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("webhook", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 
@@ -168,7 +168,7 @@ func (c *MutatingWebhookConfigurationControl) Upsert(ctx context.Context) error 
 	}
 
 	if checkCustomerManagedResource(currentWebhook.Annotations) {
-		c.WithField("mutatingwebhook", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		c.WithField("mutatingwebhook", formatMeta(c.ObjectMeta)).Info("Skipping update since object is customer managed.")
 		return nil
 	}
 

--- a/webhook.go
+++ b/webhook.go
@@ -85,6 +85,12 @@ func (c *ValidatingWebhookConfigurationControl) Upsert(ctx context.Context) erro
 		_, err = c.client().Create(c.ValidatingWebhookConfiguration)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(currentWebhook.Annotations) {
+		c.WithField("webhook", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	c.ResourceVersion = currentWebhook.ResourceVersion
 	_, err = c.client().Update(c.ValidatingWebhookConfiguration)
 	return ConvertError(err)
@@ -160,6 +166,12 @@ func (c *MutatingWebhookConfigurationControl) Upsert(ctx context.Context) error 
 		_, err = c.client().Create(c.MutatingWebhookConfiguration)
 		return ConvertError(err)
 	}
+
+	if checkCustomerManagedResource(currentWebhook.Annotations) {
+		c.WithField("mutatingwebhook", formatMeta(c.ObjectMeta)).Infof("Skipping update since object is customer managed.")
+		return nil
+	}
+
 	c.ResourceVersion = currentWebhook.ResourceVersion
 	_, err = c.client().Update(c.MutatingWebhookConfiguration)
 	return ConvertError(err)


### PR DESCRIPTION
Update https://github.com/gravitational/gravity/issues/2285

Creates a new feature in rigging, that will allow customer to update / replace gravity controlled objects, and as long as those objects contain the `gravitational.io/customer-managed` annotation to the object, rigging will no longer update the object. For now this is really for a specific use case of DNS configmaps and specifically the proportional autoscaler config. 

Also for now, I haven't tried to tackle deletions or more complicated object changes, as we haven't prepared a clear design on how to handle those more complicated changes. For now, this minimal change should meet customer requirements.


### Testing done
1. Create test cluster
2. Create / update an object like the configmap `kube-system/autoscaler-coredns-worker` with the annotation `gravitational.io/customer-managed: "true"`. 
IE Use https://github.com/gravitational/gravity/blob/master/assets/dns-app/resources/dns.yaml#L417-L951 as a reference, make some changes, and add the annotation.
3. Run an upgrade with the rigging changes, and observe the configmap is unchanged by the upgrade.