### PR TITLE
Re-entrancy on rigging + upgrade tweaks

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -128,6 +128,13 @@ type Changeset struct {
 
 // Upsert upserts resource in a context of a changeset
 func (cs *Changeset) Upsert(ctx context.Context, changesetNamespace, changesetName string, data []byte) error {
+	// To support re-entrant calls to Upsert, we need to check to see if the last operation in the changeset is
+	// incomplete. If it is incomplete, we roll it back before continuing.
+	err := cs.RevertIncompleteOperation(ctx, changesetNamespace, changesetName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), DefaultBufferSize)
 
 	for {
@@ -234,6 +241,14 @@ func (cs *Changeset) Status(ctx context.Context, changesetNamespace, changesetNa
 
 	if retryPeriod == 0 {
 		retryPeriod = DefaultRetryPeriod
+	}
+
+	// If any operation in the changeset is incomplete, the status won't update in the retry loop to be complete.
+	// So early exit if the changeset will not pass the status check in it's current state.
+	for _, op := range tr.Spec.Items {
+		if op.Status == OpStatusCreated {
+			return trace.BadParameter("%v is not completed yet. Changelog needs to be rolled back.", tr)
+		}
 	}
 
 	return retry(ctx, retryAttempts, retryPeriod, func() error {
@@ -372,21 +387,71 @@ func (cs *Changeset) Revert(ctx context.Context, changesetNamespace, changesetNa
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if op.Status != OpStatusCompleted {
-			log.Infof("skipping changeset item %v, status: %v is not the expected %v", info, op.Status, OpStatusCompleted)
-		}
+
+		log.Infof("Reverting changeset item %v, status: %v ", info, op.Status)
 		if err := cs.revert(ctx, op, info); err != nil {
 			return trace.Wrap(err)
 		}
+
 		op.Status = OpStatusReverted
+
+		tr, err = cs.update(tr)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+	}
+
+	tr.Spec.Status = ChangesetStatusReverted
+	_, err = cs.update(tr)
+	return trace.Wrap(err)
+}
+
+// RevertIncompleteOperation checks and rollbacks the last operation in the changeset if it's incomplete.
+func (cs *Changeset) RevertIncompleteOperation(ctx context.Context, changesetNamespace, changesetName string) error {
+	tr, err := cs.get(changesetNamespace, changesetName)
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return nil
+		}
+		return trace.Wrap(err)
+	}
+
+	if tr.Spec.Status == ChangesetStatusReverted {
+		return nil
+	}
+
+	if len(tr.Spec.Items) == 0 {
+		return nil
+	}
+
+	log := log.WithFields(log.Fields{
+		"cs": tr.String(),
+	})
+
+	op := &tr.Spec.Items[len(tr.Spec.Items)-1]
+	if op.Status == OpStatusCreated {
+		info, err := GetOperationInfo(*op)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		log.Infof("Reverting incomplete changeset item %v, status: %v ", info, op.Status)
+		if err := cs.revert(ctx, op, info); err != nil {
+			return trace.Wrap(err)
+		}
+
+		// Remove the item from the changelog that we rolled back so `rig freeze` doesn't see the changelog as
+		// incomplete.
+		tr.Spec.Items = tr.Spec.Items[:len(tr.Spec.Items)-1]
+
 		tr, err = cs.update(tr)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 	}
-	tr.Spec.Status = ChangesetStatusReverted
-	_, err = cs.update(tr)
-	return trace.Wrap(err)
+
+	return nil
 }
 
 func (cs *Changeset) status(ctx context.Context, data []byte, uid string) error {
@@ -2067,7 +2132,7 @@ func (cs *Changeset) upsertJob(ctx context.Context, tr *ChangesetResource, data 
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
-		log.Info("existing job not found")
+		log.Debug("existing job not found")
 		current = nil
 	}
 	control, err := NewJobControl(JobConfig{Job: job, Clientset: cs.Client})

--- a/ds.go
+++ b/ds.go
@@ -92,7 +92,7 @@ func (c *DSControl) Delete(ctx context.Context, cascade bool) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	c.Info("deleting current daemon set")
+	c.Debug("deleting current daemon set")
 	deletePolicy := metav1.DeletePropagationForeground
 	err = daemons.Delete(c.DaemonSet.Name, &metav1.DeleteOptions{
 		PropagationPolicy: &deletePolicy,
@@ -126,7 +126,7 @@ func (c *DSControl) Upsert(ctx context.Context) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		// api always returns object, this is inconvenent
+		// api always returns object, this is inconvenient
 		currentDS = nil
 	}
 
@@ -146,7 +146,7 @@ func (c *DSControl) Upsert(ctx context.Context) error {
 		}
 	}
 
-	c.Info("creating new daemon set")
+	c.Debug("creating new daemon set")
 	c.DaemonSet.UID = ""
 	c.DaemonSet.SelfLink = ""
 	c.DaemonSet.ResourceVersion = ""

--- a/job.go
+++ b/job.go
@@ -54,7 +54,7 @@ func (c *JobControl) Delete(ctx context.Context, cascade bool) error {
 		return trace.Wrap(err)
 	}
 
-	c.Info("deleting current job")
+	c.Debug("deleting current job")
 	deletePolicy := metav1.DeletePropagationForeground
 	err = jobs.Delete(c.Job.Name, &metav1.DeleteOptions{
 		PropagationPolicy: &deletePolicy,
@@ -108,7 +108,7 @@ func (c *JobControl) Upsert(ctx context.Context) error {
 		}
 	}
 
-	c.Info("creating new job")
+	c.Debug("creating new job")
 	c.Job.UID = ""
 	c.Job.SelfLink = ""
 	c.Job.ResourceVersion = ""

--- a/rcc.go
+++ b/rcc.go
@@ -93,7 +93,7 @@ func (c *RCControl) Delete(ctx context.Context, cascade bool) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	c.Info("deleting current replication controller")
+	c.Debug("deleting current replication controller")
 	deletePolicy := metav1.DeletePropagationForeground
 	err = rcs.Delete(c.ReplicationController.Name, &metav1.DeleteOptions{
 		PropagationPolicy: &deletePolicy,

--- a/tool/rig/main.go
+++ b/tool/rig/main.go
@@ -423,7 +423,7 @@ func csDelete(ctx context.Context, client *kubernetes.Clientset, config *rest.Co
 
 // InitLoggerCLI tools by default log into syslog, not stderr
 func InitLoggerCLI() {
-	log.SetLevel(log.WarnLevel)
+	log.SetLevel(log.InfoLevel)
 	// clear existing hooks:
 	log.StandardLogger().Hooks = make(log.LevelHooks)
 	log.SetFormatter(&trace.TextFormatter{})

--- a/utils.go
+++ b/utils.go
@@ -366,7 +366,7 @@ func waitForObjectDeletion(fn func() error) error {
 
 const (
 	deletePollInterval = 1 * time.Second
-	deleteTimeout      = 5 * time.Minute
+	deleteTimeout      = 10 * time.Minute
 )
 
 func checkCustomerManagedResource(annotations map[string]string) bool {


### PR DESCRIPTION
This mainly adjusts rigging to operate closer to how customers actually try and use rigging (via gravity). Customers have gotten in the habit of just trying to resume a failed upgrade step, of which rigging isn't always re-entrant when this is attempted. Rigging will operate normally by rollback + upgrade, but that's not how customers are using the project.

Changes:
- If the last change is the changeset (the changelog) hasn't been completed which will cause later status checks to fail. Instead when upserting configuration, check if the last item is incomplete, and rollback before proceeding.
  - Note: I only check the last item and rollback only the last item. This should be reasonable in the examples of this failure mode I've seen, and is the least invasive change.
  - Note: It could probably be argued that this should rollback the entire changelog before continuing, but rigging isn't really setup for this, so only tackle the last changelog entry which is the minimal change.
- Update default log level to Info, so it's easier to debug / investigate changes and timeouts
  - Note: I also downgraded a couple logs to debug to be inline with this change.
- Status checks will early exit if they will be unable to proceed in the Retry loop.
- Doubles the deleteTimeout, how long rigging waits for a delete to complete. A customer is regularly overloading their cluster to the point where delete + pod GC takes more than this 5 minutes. I don't have any insight into how long this actually takes, so doubling from 5 -> 10 minutes is an educated guess that the customers apps instability should be less likely to encounter this timeout.


Testing:
1. Run an upgrade phase with this rigging build, for example the dns-app upgrade phase.
2. Edit the changeset to set the overall state to `in-progress` and the last changeset item status to `started`. 
    Note: This is the state the changeset will be in if a step like a delete of Daemonset timed out. 
3. Re-run the upgrade phase within gravity with the `--force` flag.
4. Confirm that the upgrade job completes / check logs of the update pod.

Logs:
```
root@kevin-test1:~/7.0.26# kubectl -n kube-system logs dns-app-update-0b20a3-ln57l
+ echo Assuming changeset from the environment: dns-713
Assuming changeset from the environment: dns-713
+ [ update = update ]
Updating resources
+ echo Updating resources
+ rig upsert -f /var/lib/gravity/resources/dns.yaml
2020-12-07T05:35:32Z INFO             Reverting incomplete changeset item update Deployment kube-system/autoscaler-coredns-worker, status: created  cs:namespace=default, name=dns-713, operations=32) rigging/changeset.go:440
2020-12-07T05:35:32Z INFO             upsert kube-system/autoscaler-coredns-worker deployment:kube-system/autoscaler-coredns-worker rigging/deployment.go:121
2020-12-07T05:35:33Z INFO             upsert coredns podsecuritypolicy:coredns rigging/policies.go:77
2020-12-07T05:35:33Z INFO             upsert kube-system/coredns service_account:kube-system/coredns rigging/serviceaccount.go:77
2020-12-07T05:35:33Z INFO             upsert system:coredns cluster_role:system:coredns rigging/roles.go:156
2020-12-07T05:35:34Z INFO             upsert system:coredns cluster_role_binding:system:coredns rigging/roles.go:314
2020-12-07T05:35:35Z INFO             upsert daemon set kube-system/coredns cs:namespace=default, name=dns-713, operations=35) ds:kube-system/coredns rigging/changeset.go:2160
2020-12-07T05:35:35Z INFO             upsert kube-system/coredns daemonset:kube-system/coredns rigging/ds.go:122
2020-12-07T05:35:35Z INFO             delete kube-system/coredns daemonset:kube-system/coredns rigging/ds.go:85
2020-12-07T05:35:35Z INFO             found pod kube-system/coredns-r64nc on node 10.162.0.7 daemonset:kube-system/coredns rigging/utils.go:117
2020-12-07T05:35:44Z INFO             upsert deployment kube-system/coredns-worker cs:namespace=default, name=dns-713, operations=36) deployment:kube-system/coredns-worker rigging/changeset.go:2256
2020-12-07T05:35:44Z INFO             upsert kube-system/coredns-worker deployment:kube-system/coredns-worker rigging/deployment.go:121
2020-12-07T05:35:44Z INFO             upsert service kube-system/kube-dns cs:namespace=default, name=dns-713, operations=37) service:kube-system/kube-dns rigging/changeset.go:2288
2020-12-07T05:35:44Z INFO             upsert kube-system/kube-dns service:kube-system/kube-dns rigging/service.go:77
2020-12-07T05:35:44Z INFO             upsert service kube-system/kube-dns-worker cs:namespace=default, name=dns-713, operations=38) service:kube-system/kube-dns-worker rigging/changeset.go:2288
2020-12-07T05:35:44Z INFO             upsert kube-system/kube-dns-worker service:kube-system/kube-dns-worker rigging/service.go:77
2020-12-07T05:35:45Z INFO             upsert kube-system/cluster-proportional-autoscaler-coredns service_account:kube-system/cluster-proportional-autoscaler-coredns rigging/serviceaccount.go:77
2020-12-07T05:35:46Z INFO             upsert cluster-proportional-autoscaler podsecuritypolicy:cluster-proportional-autoscaler rigging/policies.go:77
2020-12-07T05:35:47Z INFO             upsert cluster-proportional-autoscaler-coredns cluster_role:cluster-proportional-autoscaler-coredns rigging/roles.go:156
2020-12-07T05:35:48Z INFO             upsert kube-system/cluster-proportional-autoscaler-coredns role:kube-system/cluster-proportional-autoscaler-coredns rigging/roles.go:77
2020-12-07T05:35:48Z INFO             upsert cluster-proportional-autoscaler-coredns cluster_role_binding:cluster-proportional-autoscaler-coredns rigging/roles.go:314
2020-12-07T05:35:49Z INFO             upsert kube-system/cluster-proportional-autoscaler-coredns role_binding:kube-system/cluster-proportional-autoscaler-coredns rigging/roles.go:235
2020-12-07T05:35:50Z INFO             upsert configmap kube-system/autoscaler-coredns-worker configMap:kube-system/autoscaler-coredns-worker cs:namespace=default, name=dns-713, operations=45) rigging/changeset.go:2834
2020-12-07T05:35:50Z INFO             upsert kube-system/autoscaler-coredns-worker configMap:kube-system/autoscaler-coredns-worker rigging/configmap.go:77
2020-12-07T05:35:51Z INFO             upsert deployment kube-system/autoscaler-coredns-worker cs:namespace=default, name=dns-713, operations=46) deployment:kube-system/autoscaler-coredns-worker rigging/changeset.go:2256
2020-12-07T05:35:51Z INFO             upsert kube-system/autoscaler-coredns-worker deployment:kube-system/autoscaler-coredns-worker rigging/deployment.go:121
changeset dns-713 updated
+ echo Deleting coredns daemonset that has been replaced by a deployment
+ rig delete ds/coredns-worker --resource-namespace=kube-system --force
Deleting coredns daemonset that has been replaced by a deployment
2020-12-07T05:35:51Z INFO             Deleting kube-system/{DaemonSet coredns-worker} cs:namespace=default, name=dns-713, operations=47) rigging/changeset.go:299
DaemonSet/coredns-worker is not found, force flag is set, dns-713 not updated, ignoring
+ echo Checking status
+ rig status dns-713 --retry-attempts=600 --retry-period=1s --debug
Checking status
2020-12-07T05:35:51Z DEBU             changeset init logrus/exported.go:77
2020-12-07T05:35:51Z INFO             found pod kube-system/coredns-qd5cn on node 10.162.0.7 daemonset:kube-system/coredns rigging/utils.go:117
2020-12-07T05:35:51Z INFO             node 10.162.0.7: pod kube-system/coredns-qd5cn is up and running daemonset:kube-system/coredns rigging/utils.go:199
2020-12-07T05:35:51Z INFO             found pod kube-system/coredns-qd5cn on node 10.162.0.7 daemonset:kube-system/coredns rigging/utils.go:117
2020-12-07T05:35:51Z INFO             node 10.162.0.7: pod kube-system/coredns-qd5cn is up and running daemonset:kube-system/coredns rigging/utils.go:199
2020-12-07T05:35:52Z INFO             found pod kube-system/coredns-qd5cn on node 10.162.0.7 daemonset:kube-system/coredns rigging/utils.go:117
2020-12-07T05:35:53Z INFO             node 10.162.0.7: pod kube-system/coredns-qd5cn is up and running daemonset:kube-system/coredns rigging/utils.go:199
no errors detected for dns-713
+ echo Freezing
+ rig freeze
Freezing
changeset dns-713 frozen, no further modifications are allowed
```