### PR TITLE
Skip revert on operations that are already reverted

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -383,6 +383,12 @@ func (cs *Changeset) Revert(ctx context.Context, changesetNamespace, changesetNa
 	})
 	for i := len(tr.Spec.Items) - 1; i >= 0; i-- {
 		op := &tr.Spec.Items[i]
+
+		// Reentrancy: skip any phases that may already be reverted by a previous rollback
+		if op.Status == OpStatusReverted {
+			continue
+		}
+
 		info, err := GetOperationInfo(*op)
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
Observed this on another customer cluster. Rolling back an app phase up to 7 times without success since they all timed out. Inspecting the changelog object on one attempt, it was actually down to the last two changes when timing out.

So make the rollback re-entrant by skipping any phases that are already marked as reverted.