### PR TITLE
[7.0.x] Add Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -111,3 +111,8 @@ services:
 volumes:
   - name: dockersock
     temp: {}
+---
+kind: signature
+hmac: 6dd4a5949f32f88a31f6915a81064184c03ff454ddd02dfac7242f44394464fc
+
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,113 @@
+---
+kind: pipeline
+type: kubernetes
+name: pr
+
+trigger:
+  event:
+  - pull_request
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build binary
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make docker-build
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: test
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make docker-test
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build container
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make docker-image
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: publish
+
+trigger:
+  event:
+  - push
+  - tag
+  branch:
+  - master
+  - version/**
+
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish
+    image: docker:git
+    environment:
+      USERNAME:
+        from_secret: quay_username
+      PASSWORD:
+        from_secret: quay_password
+    commands:
+      - apk add --no-cache make
+      - docker login -u="$USERNAME" -p="$PASSWORD" quay.io
+      - make docker-image
+      - make publish-docker-image
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ docker-image: docker-build
 	  echo "TEMPDIR is not set"; exit 1; \
 	fi;
 	mkdir -p $(TEMPDIR)/build
-	BUILDDIR=$(TEMPDIR)/build $(MAKE) docker-build
+	cp build/rig $(TEMPDIR)/build/rig
 	cp -r docker/rig.dockerfile $(TEMPDIR)/Dockerfile
 	cd $(TEMPDIR) && docker build --pull -t $(IMAGE) .
 	rm -rf $(TEMPDIR)

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ docker-test:
 		   /bin/bash -c "make -C $(DST) test"
 
 .PHONY: docker-image
-docker-image:
-	$(eval TEMPDIR = "$(shell mktemp -d)")
+docker-image: docker-build
+	$(eval TEMPDIR = "$(shell mktemp -d $(BUILDDIR)/tmp.XXXXXX)")
 	if [ -z "$(TEMPDIR)" ]; then \
 	  echo "TEMPDIR is not set"; exit 1; \
 	fi;

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ IMAGE := quay.io/gravitational/rig:$(VERSION)
 .PHONY: docker-build
 docker-build:
 	docker run -i --rm=true \
+		   -u $$(id -u):$$(id -g) -e GOCACHE=/tmp/.cache \
 		   -v $(SRC):$(DST) \
 		   -v $(BUILDDIR):$(DST)/build \
 		   $(BUILDBOX) \


### PR DESCRIPTION
## Summary
This PR backports #88. I add Drone CI validation & publishing for 7.0, because we're moving to deprecate Jenkins. The changes are exactly the same as master.

## Testing Done

The PR build is sufficient for the PR pipline.  Publishing was tested on master at https://drone.gravitational.io/gravitational/rigging/9/2/1 and https://quay.io/repository/gravitational/rig?tab=tags (tag 7.0.2-15-g61be542b). 7.0 doesn't have significant differences that merit re-testing publishing AFAICT.