### PR TITLE
Replace ExtensionsV1beta1 -> PolicyV1beta1

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -843,7 +843,7 @@ func (cs *Changeset) statusPodSecurityPolicy(ctx context.Context, data []byte, u
 		return trace.Wrap(err)
 	}
 	if uid != "" {
-		existing, err := cs.Client.ExtensionsV1beta1().PodSecurityPolicies().Get(policy.Name, metav1.GetOptions{})
+		existing, err := cs.Client.PolicyV1beta1().PodSecurityPolicies().Get(policy.Name, metav1.GetOptions{})
 		if err != nil {
 			return ConvertError(err)
 		}
@@ -1394,7 +1394,7 @@ func (cs *Changeset) deleteClusterRoleBinding(ctx context.Context, tr *Changeset
 }
 
 func (cs *Changeset) deletePodSecurityPolicy(ctx context.Context, tr *ChangesetResource, name string, cascade bool) error {
-	policy, err := cs.Client.ExtensionsV1beta1().PodSecurityPolicies().Get(name, metav1.GetOptions{})
+	policy, err := cs.Client.PolicyV1beta1().PodSecurityPolicies().Get(name, metav1.GetOptions{})
 	if err != nil {
 		return ConvertError(err)
 	}
@@ -2772,7 +2772,7 @@ func (cs *Changeset) upsertPodSecurityPolicy(ctx context.Context, tr *ChangesetR
 		"cs":                  tr.String(),
 		"pod_security_policy": formatMeta(policy.ObjectMeta),
 	})
-	policies := cs.Client.ExtensionsV1beta1().PodSecurityPolicies()
+	policies := cs.Client.PolicyV1beta1().PodSecurityPolicies()
 	current, err := policies.Get(policy.Name, metav1.GetOptions{})
 	err = ConvertError(err)
 	if err != nil {

--- a/parse.go
+++ b/parse.go
@@ -23,7 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	extensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"

--- a/policies.go
+++ b/policies.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -67,14 +67,14 @@ type PodSecurityPolicyControl struct {
 func (c *PodSecurityPolicyControl) Delete(ctx context.Context, cascade bool) error {
 	c.Infof("delete %v", formatMeta(c.ObjectMeta))
 
-	err := c.Client.ExtensionsV1beta1().PodSecurityPolicies().Delete(c.Name, nil)
+	err := c.Client.PolicyV1beta1().PodSecurityPolicies().Delete(c.Name, nil)
 	return ConvertError(err)
 }
 
 func (c *PodSecurityPolicyControl) Upsert(ctx context.Context) error {
 	c.Infof("upsert %v", formatMeta(c.ObjectMeta))
 
-	policies := c.Client.ExtensionsV1beta1().PodSecurityPolicies()
+	policies := c.Client.PolicyV1beta1().PodSecurityPolicies()
 	c.UID = ""
 	c.SelfLink = ""
 	c.ResourceVersion = ""
@@ -98,7 +98,7 @@ func (c *PodSecurityPolicyControl) Upsert(ctx context.Context) error {
 }
 
 func (c *PodSecurityPolicyControl) Status() error {
-	policies := c.Client.ExtensionsV1beta1().PodSecurityPolicies()
+	policies := c.Client.PolicyV1beta1().PodSecurityPolicies()
 	_, err := policies.Get(c.Name, metav1.GetOptions{})
 	return ConvertError(err)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,17 +4,14 @@ github.com/alecthomas/template/parse
 # github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
 github.com/alecthomas/units
 # github.com/coreos/prometheus-operator v0.0.0-00010101000000-000000000000 => github.com/gravitational/prometheus-operator v0.35.2
-## explicit
 github.com/coreos/prometheus-operator/pkg/apis/monitoring
 github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1
 github.com/coreos/prometheus-operator/pkg/client/versioned
 github.com/coreos/prometheus-operator/pkg/client/versioned/scheme
 github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1
 # github.com/davecgh/go-spew v1.1.1
-## explicit
 github.com/davecgh/go-spew/spew
 # github.com/ghodss/yaml v1.0.0
-## explicit
 github.com/ghodss/yaml
 # github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48
 github.com/gogo/protobuf/proto
@@ -28,15 +25,12 @@ github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/gofuzz v1.0.0
 github.com/google/gofuzz
 # github.com/googleapis/gnostic v0.1.0
-## explicit
 github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 # github.com/gravitational/trace v1.1.6-0.20180717152918-4a5e142f3251
-## explicit
 github.com/gravitational/trace
 # github.com/imdario/mergo v0.3.6
-## explicit
 github.com/imdario/mergo
 # github.com/jonboulle/clockwork v0.1.0
 github.com/jonboulle/clockwork
@@ -47,20 +41,17 @@ github.com/kr/pretty
 # github.com/kr/text v0.1.0
 github.com/kr/text
 # github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
-## explicit
 github.com/kylelemons/godebug/diff
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
 # github.com/sirupsen/logrus v1.4.2 => github.com/gravitational/logrus v0.10.1-0.20180402202453-dcdb95d728db
-## explicit
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
 # golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
-## explicit
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 golang.org/x/net/context
@@ -81,7 +72,6 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-## explicit
 golang.org/x/time/rate
 # google.golang.org/appengine v1.5.0
 google.golang.org/appengine/internal
@@ -91,22 +81,15 @@ google.golang.org/appengine/internal/log
 google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/urlfetch
-# gopkg.in/airbrake/gobrake.v2 v2.0.9
-## explicit
 # gopkg.in/alecthomas/kingpin.v2 v2.2.6
-## explicit
 gopkg.in/alecthomas/kingpin.v2
 # gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
-## explicit
 gopkg.in/check.v1
-# gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2
-## explicit
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2
 # k8s.io/api v0.16.15
-## explicit
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1
@@ -146,7 +129,6 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65
-## explicit
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
@@ -155,7 +137,6 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1
 # k8s.io/apimachinery v0.16.15
-## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -193,7 +174,6 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.0.0-20191016111102-bec269661e48
-## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/kubernetes
 k8s.io/client-go/kubernetes/scheme
@@ -258,7 +238,6 @@ k8s.io/client-go/util/keyutil
 # k8s.io/klog v1.0.0
 k8s.io/klog
 # k8s.io/kube-aggregator v0.0.0-20191016112429-9587704a8ad4
-## explicit
 k8s.io/kube-aggregator/pkg/apis/apiregistration
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
@@ -271,6 +250,3 @@ k8s.io/utils/integer
 k8s.io/utils/pointer
 # sigs.k8s.io/yaml v1.1.0
 sigs.k8s.io/yaml
-# k8s.io/client-go => k8s.io/client-go v0.0.0-20191016111102-bec269661e48
-# github.com/sirupsen/logrus => github.com/gravitational/logrus v0.10.1-0.20180402202453-dcdb95d728db
-# github.com/coreos/prometheus-operator => github.com/gravitational/prometheus-operator v0.35.2


### PR DESCRIPTION
## Description
`PodSecurityPolicies` has been deprecated in `ExtensionsV1beta1` in Kubernetes 1.19. Use `PolicyV1beta1` instead.