### PR TITLE
Only publish when tagged

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -64,12 +64,7 @@ name: publish
 
 trigger:
   event:
-  - push
   - tag
-  branch:
-  - master
-  - version/**
-
 
 steps:
   - name: fetch tags

--- a/.drone.yml
+++ b/.drone.yml
@@ -108,6 +108,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 6dd4a5949f32f88a31f6915a81064184c03ff454ddd02dfac7242f44394464fc
+hmac: 6354bb0b04505fcd538816731b36b8505df0ee4ee42c43e1e83f41d93dd30d84
 
 ...


### PR DESCRIPTION
## Description
It looks like if we want to execute a pipeline on either a tag or push to specific branch we need separate pipelines.
https://discourse.drone.io/t/cannot-execute-a-pipeline-on-either-tag-or-push-to-specific-branch/3490

I don't think we need to be publishing images when pushing to `master` or `version/**`, so the publish pipeline now only triggers on tags.