### PR TITLE
[7.0] Update .drone.yml for drone.teleport.dev

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -83,9 +83,9 @@ steps:
     image: docker:git
     environment:
       USERNAME:
-        from_secret: quay_username
+        from_secret: QUAY_USERNAME
       PASSWORD:
-        from_secret: quay_password
+        from_secret: QUAY_PASSWORD
     commands:
       - apk add --no-cache make
       - docker login -u="$USERNAME" -p="$PASSWORD" quay.io
@@ -108,6 +108,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 6354bb0b04505fcd538816731b36b8505df0ee4ee42c43e1e83f41d93dd30d84
+hmac: 0ea09c32999a30606f81cdef8bfeaede3b4aadb5666d88f4fda6439776f631ce
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -64,12 +64,7 @@ name: publish
 
 trigger:
   event:
-  - push
   - tag
-  branch:
-  - master
-  - version/**
-
 
 steps:
   - name: fetch tags
@@ -113,6 +108,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 6dd4a5949f32f88a31f6915a81064184c03ff454ddd02dfac7242f44394464fc
+hmac: 6354bb0b04505fcd538816731b36b8505df0ee4ee42c43e1e83f41d93dd30d84
 
 ...


### PR DESCRIPTION
7.0 backport of https://github.com/gravitational/rigging/pull/101 and https://github.com/gravitational/rigging/pull/97 (which was only to master).

Not urgent, but we need this before anything else can go into 7.0.  I probably wont backport this any further unless we need to release from 6.1 o5 5.5.

## Testing Done
See the PR build.